### PR TITLE
Run/blended fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21270,9 +21270,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.7.tgz",
-      "integrity": "sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==",
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.24.2",

--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -15,6 +15,38 @@
     "debug_prompt": {
       "en": "Debug?",
       "fr": "Débogage ?"
+    },
+        "select_hebrewscriptfont": {
+      "en": "Hebrew Script Font",
+      "fr": "Police d'écriture Hébraïque"
+    },
+    "select_myanmarscriptfont": {
+      "en": "Myanmar Script Font",
+      "fr": "Police d'écriture Myanmar"
+    },
+    "select_arabicurduscriptfont": {
+      "en": "Arabic/Urdu Script Font",
+      "fr": "Police d'écriture Arabe/Ourdou"
+    },
+    "select_otherscriptfont": {
+      "en": "Other Script Font",
+      "fr": "Autre police d'écriture"
+    },
+    "select_fallbackscriptfont": {
+      "en": "Fallback Script Font",
+      "fr": "Police d'écriture de retomber"
+    },
+    "other-fallback": {
+      "en": "Other/Fallback",
+      "fr": "Autre/Retomber"
+    },
+    "fallback": {
+      "en": "Fallback",
+      "fr": "Retomber"
+    },
+    "replaceawamiifnotfirefox": {
+      "en": "* Noto Nastaliq Urdu 2022 if not Firefox",
+      "fr": "* Noto Nastaliq Urdu 2022 sinon Firefox"
     }
   }
 }

--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -16,7 +16,7 @@
       "en": "Debug?",
       "fr": "Débogage ?"
     },
-        "select_hebrewscriptfont": {
+    "select_hebrewscriptfont": {
       "en": "Hebrew Script Font",
       "fr": "Police d'écriture Hébraïque"
     },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,10 +23,10 @@ function App() {
       []
     );
     useEffect( () => {
-      setSelectedFontClass(fontClass.font_class);
-    },[fontClass.font_class]);
+      setSelectedFontClass(fontClass.font_set);
+    },[fontClass.font_set]);
 
-    const activeFontClass = fontClass.font_class;
+    const activeFontClass = fontClass.font_set;
 
     const pithekosToolbarProps = {
       activeFontClass,
@@ -61,17 +61,17 @@ function App() {
                 <Grid2 item size={12}>
                   <Box sx={{ borderTop: 1 }}>
                     <br/>
-                    <b>Active font_class:</b> {fontClass.font_class}<br/><br/>
-                    <b>Change font_class:</b><br />
+                    <b>Active font_set:</b> {fontClass.font_set}<br/><br/>
+                    <b>Change font_set:</b><br />
                     <PithekosToolbar key="pithekos toolbar" {...pithekosToolbarProps} />
-                    {fontClass.font_class !== selectedFontClass &&
+                    {fontClass.font_set !== selectedFontClass &&
                       <Box sx={{ paddingLeft: "20pt" }}>
                         <em>Instructions:</em>
                         <ol>
-                          <li>Change font_class in <em>~/pankosmia_working/user_settings.json</em>
+                          <li>Change font_set in <em>~/pankosmia_working/user_settings.json</em>
                             <ul>
-                              <li><b>from:</b> "font_class": "{fontClass.font_class}",</li>
-                              <li><b>to:</b> "font_class": "{selectedFontClass}",</li>
+                              <li><b>from:</b> "font_set": "{fontClass.font_set}",</li>
+                              <li><b>to:</b> "font_set": "{selectedFontClass}",</li>
                             </ul>
                           </li>
                           <li>Save <em>~/pankosmia_working/user_settings.json.</em></li>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,54 @@
-import {useContext} from "react"
-import {Grid2, Switch} from "@mui/material";
-import {debugContext, i18nContext, doI18n, getJson} from "pithekos-lib";
+import {useContext, useState, useEffect} from "react"
+import {Grid2, Switch, Box} from "@mui/material";
+import {debugContext, i18nContext, doI18n, getJson, getAndSetJson} from "pithekos-lib";
+import PithekosToolbar from "./components/PithekosToolbar";
 
 function App() {
-        const {debugRef} = useContext(debugContext);
+    const {debugRef} = useContext(debugContext);
     const i18n = useContext(i18nContext);
+    const [selectedHebrewFontClass, setSelectedHebrewFontClass] = useState('');
+    const [selectedMyanmarFontClass, setSelectedMyanmarFontClass] = useState('');
+    const [selectedArabicUrduFontClass, setSelectedArabicUrduFontClass] = useState('');
+    const [selectedOtherFontClass, setSelectedOtherFontClass] = useState('');
+    const [selectedFallbackFontClass, setSelectedFallbackFontClass] = useState('');
+    const [selectedFontClass, setSelectedFontClass] = useState('');
+    // const [activeFontClass, setActiveFontClass] = useState('');
+    const [fontClass, setFontClass] = useState([]);
+    useEffect(
+      () => {
+          getAndSetJson({
+              url: "/settings/typography",
+              setter: setFontClass
+          }).then()},
+      []
+    );
+    useEffect( () => {
+      setSelectedFontClass(fontClass.font_class);
+    },[fontClass.font_class]);
+
+    const activeFontClass = fontClass.font_class;
+
+    const pithekosToolbarProps = {
+      activeFontClass,
+      setSelectedFontClass,
+      selectedHebrewFontClass,
+      setSelectedHebrewFontClass,
+      selectedMyanmarFontClass,
+      setSelectedMyanmarFontClass,
+      selectedArabicUrduFontClass,
+      setSelectedArabicUrduFontClass,
+      selectedOtherFontClass,
+      setSelectedOtherFontClass,
+      selectedFallbackFontClass,
+      setSelectedFallbackFontClass,
+    };
+
     return (
             <Grid2 container>
-                <Grid2 item size={6}>
-                    {doI18n("pages:core-settings:debug_prompt", i18n)}
+                <Grid2 item size={2}>
+                    <b>{doI18n("pages:core-settings:debug_prompt", i18n)}</b>
                 </Grid2>
-                <Grid2 item size={6}>
+                <Grid2 item size={10}>
                     <Switch
                         checked={debugRef.current}
                         onChange={() =>
@@ -20,9 +58,32 @@ function App() {
                         }
                     />
                 </Grid2>
+                <Grid2 item size={12}>
+                  <Box sx={{ borderTop: 1 }}>
+                    <br/>
+                    <b>Active font_class:</b> {fontClass.font_class}<br/><br/>
+                    <b>Change font_class:</b><br />
+                    <PithekosToolbar key="pithekos toolbar" {...pithekosToolbarProps} />
+                    {fontClass.font_class !== selectedFontClass &&
+                      <Box sx={{ paddingLeft: "20pt" }}>
+                        <em>Instructions:</em>
+                        <ol>
+                          <li>Change font_class in <em>~/pankosmia_working/user_settings.json</em>
+                            <ul>
+                              <li><b>from:</b> "font_class": "{fontClass.font_class}",</li>
+                              <li><b>to:</b> "font_class": "{selectedFontClass}",</li>
+                            </ul>
+                          </li>
+                          <li>Save <em>~/pankosmia_working/user_settings.json.</em></li>
+                          <li>Restart the Pithekos web server.</li>
+                          <li>Reopen <em>http://localhost:8000</em> in Firefox.</li>
+                        </ol>
+                      </Box>
+                    }
+                  </Box>
+                </Grid2>
             </Grid2>
     )
-
 }
 
 export default App;

--- a/src/components/FontMenuItem.jsx
+++ b/src/components/FontMenuItem.jsx
@@ -1,0 +1,38 @@
+import { PropTypes } from "prop-types";
+import { Typography } from "@mui/material";
+
+export default function FontMenuItem(fontMenuItemProps) {
+  const { font } = fontMenuItemProps;
+
+  const styles = {
+    menuItem: {
+      display: "flex",
+      justifyContent: "space-between",
+      color: 'DimGray',
+    },
+  };
+
+  return (
+    <div style={(styles.menuItem)}>
+      <div
+        style={styles.menuItem}
+      >
+        <Typography
+          style={{ width: "100%" }}
+          noWrap
+          variant="body2"
+          component="div"
+        >
+          {font.name}
+        </Typography>
+      </div>
+    </div>
+  );
+}
+
+FontMenuItem.propTypes = {
+  font: PropTypes.shape({
+    fullname: PropTypes.string,
+    name: PropTypes.string,
+  }),
+};

--- a/src/components/PithekosToolbar.jsx
+++ b/src/components/PithekosToolbar.jsx
@@ -1,0 +1,53 @@
+import { Toolbar } from "@mui/material";
+import PithekosToolbarSelectFont from "./PithekosToolbarSelectFont";
+// import sx from "./PithekosToolbar.styles"
+import PropTypes from 'prop-types';
+
+export default function PithekosToolbar(PithekosToolbarProps) {
+  const {
+    activeFontClass,
+    setSelectedFontClass,
+    selectedHebrewFontClass,
+    setSelectedHebrewFontClass,
+    selectedMyanmarFontClass,
+    setSelectedMyanmarFontClass,
+    selectedArabicUrduFontClass,
+    setSelectedArabicUrduFontClass,
+    selectedOtherFontClass,
+    setSelectedOtherFontClass,
+    selectedFallbackFontClass,
+    setSelectedFallbackFontClass,
+  } = PithekosToolbarProps;
+  
+  const pithekosToolbarSelectFontProps = {
+    activeFontClass,
+    setSelectedFontClass,
+    selectedHebrewFontClass,
+    setSelectedHebrewFontClass,
+    selectedMyanmarFontClass,
+    setSelectedMyanmarFontClass,
+    selectedArabicUrduFontClass,
+    setSelectedArabicUrduFontClass,
+    selectedOtherFontClass,
+    setSelectedOtherFontClass,
+    selectedFallbackFontClass,
+    setSelectedFallbackFontClass,
+  };
+  
+  return (
+    <div key="toolbar" style={{ width: '100%' }} >
+      <Toolbar sx={{ justifyContent: "space-between" }}>
+        <div style={{ textAlign: "center", fontSize: '10px'  }} key="font-menu">
+          <PithekosToolbarSelectFont {...pithekosToolbarSelectFontProps} />
+        </div>
+      </Toolbar>
+    </div>
+  );
+}
+
+PithekosToolbar.propTypes = {
+  /** Selected Font Set CSS Name */
+  selectedFontClass: PropTypes.string,
+  /** Set Selected Font Set CSS Name */
+  setSelectedFontClass: PropTypes.func.isRequired,
+};

--- a/src/components/PithekosToolbar.styles.jsx
+++ b/src/components/PithekosToolbar.styles.jsx
@@ -1,0 +1,15 @@
+export const sx = {
+  select: {
+      "&.Mui-focused .MuiOutlinedInput-notchedOutline": {borderColor: "pink", borderWidth: "thin"},
+      background: 'white',
+  },
+  inputLabel: {
+    // background: 'purple',
+    color: 'DimGray',
+    fontWeight: 400,
+    fontSize: '0.875rem',
+    "&.Mui-focused": {color: "purple"},
+  },
+}
+
+export default sx;

--- a/src/components/PithekosToolbarSelectFont.jsx
+++ b/src/components/PithekosToolbarSelectFont.jsx
@@ -37,13 +37,13 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
     const webFontsHebrew = [
       { name: 'Ezra SIL 2.51', id: 'Pankosmia-EzraSIL' },
       { name: 'Ezra SIL SR 2.51', id: 'Pankosmia-EzraSILSR' },
-      { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+      { name: '- ' + doI18n("pages:core-settings:other-fallback", i18n) + ' -', id: '' },
     ];
   
     const webFontsMyanmar = [
       { name: 'Padauk 5.100', id: 'Pankosmia-Padauk' },
       { name: 'Padauk Book 5.100', id: 'Pankosmia-PadaukBook' },
-      { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+      { name: '- ' + doI18n("pages:core-settings:other-fallback", i18n) + ' -', id: '' },
     ];
   
     const webFontsArabicUrdu = [
@@ -52,7 +52,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
       { name: 'Awami Nastaliq Semi Bold 3.300*', id: 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu' },
       { name: 'Awami Nastaliq Extra Bold 3.300*', id: 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu' },
       { name: 'Noto Naskh Arabic 2022', id: 'Pankosmia-NotoNaskhArabic' },
-      { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+      { name: '- ' + doI18n("pages:core-settings:other-fallback", i18n) + ' -', id: '' },
     ];
     
     const webFontsOther = [
@@ -65,7 +65,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
       { name: 'Roboto Light 2004', id: 'Pankosmia-RobotoLight' },
       { name: 'Roboto Medium 2004', id: 'Pankosmia-RobotoMedium' },
       { name: 'Roboto Thin 2004', id: 'Pankosmia-RobotoThin' },
-      { name: '- ' + doI18n("pages:core-client-settings:fallback", i18n) + ' -', id: '' },
+      { name: '- ' + doI18n("pages:core-settings:fallback", i18n) + ' -', id: '' },
     ];
   
     const webFontsFallback = [
@@ -85,7 +85,8 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
 
     const webFontsArabicUrduIds = webFontsArabicUrdu.map((font, index) => (font.id));
     const fontClassAwamiToAdj = fontClassIds.filter(item => item.includes('AwamiNastaliq'));
-    const activeArabicUrduId = (fontClassAwamiToAdj !== '' ? fontClassAwamiToAdj + 'Pankosmia-NotoNastaliqUrdu' : fontClassIds.filter(item => webFontsArabicUrduIds.includes(item)));
+    const activeArabicUrduIdAdj = (fontClassAwamiToAdj !== '' ? fontClassAwamiToAdj + 'Pankosmia-NotoNastaliqUrdu' : fontClassIds.filter(item => webFontsArabicUrduIds.includes(item)));
+    const activeArabicUrduId = (activeArabicUrduIdAdj === 'Pankosmia-NotoNastaliqUrdu' ? '' : activeArabicUrduIdAdj)
     setActiveArabicUrduFontClass(activeArabicUrduId);
 
     const webFontsOtherIds = webFontsOther.map((font, index) => (font.id));
@@ -132,13 +133,13 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
   const webFontsSelectableHebrew = [
     { name: 'Ezra SIL 2.51', id: 'Pankosmia-EzraSIL' },
     { name: 'Ezra SIL SR 2.51', id: 'Pankosmia-EzraSILSR' },
-    { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+    { name: '- ' + doI18n("pages:core-settings:other-fallback", i18n) + ' -', id: '' },
   ];
 
   const webFontsSelectableMyanmar = [
     { name: 'Padauk 5.100', id: 'Pankosmia-Padauk' },
     { name: 'Padauk Book 5.100', id: 'Pankosmia-PadaukBook' },
-    { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+    { name: '- ' + doI18n("pages:core-settings:other-fallback", i18n) + ' -', id: '' },
   ];
 
   const webFontsSelectableArabicUrdu = [
@@ -147,7 +148,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
     { name: 'Awami Nastaliq Semi Bold 3.300*', id: 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu' },
     { name: 'Awami Nastaliq Extra Bold 3.300*', id: 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu' },
     { name: 'Noto Naskh Arabic 2022', id: 'Pankosmia-NotoNaskhArabic' },
-    { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+    { name: '- ' + doI18n("pages:core-settings:other-fallback", i18n) + ' -', id: '' },
   ];
   
   const webFontsSelectableOther = [
@@ -160,7 +161,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
     { name: 'Roboto Light 2004', id: 'Pankosmia-RobotoLight' },
     { name: 'Roboto Medium 2004', id: 'Pankosmia-RobotoMedium' },
     { name: 'Roboto Thin 2004', id: 'Pankosmia-RobotoThin' },
-    { name: '- ' + doI18n("pages:core-client-settings:fallback", i18n) + ' -', id: '' },
+    { name: '- ' + doI18n("pages:core-settings:fallback", i18n) + ' -', id: '' },
   ];
 
   const webFontsSelectableFallback = [
@@ -210,7 +211,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
             <Box sx={{minWidth: 170}}>
                 <FormControl fullWidth style={{maxWidth: 300}} size="small">
                     <InputLabel id="select-hebrew-font-label" htmlFor="select-hebrew-font-id" sx={sx.inputLabel}>
-                      {doI18n("pages:core-client-settings:select_hebrewscriptfont", i18n)}
+                      {doI18n("pages:core-settings:select_hebrewscriptfont", i18n)}
                     </InputLabel>
                     <Select
                         variant="outlined"
@@ -220,7 +221,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
                             id: "select-hebrew-font-id",
                         }}
                         value={hebrew}
-                        label={doI18n("pages:core-client-settings:select_hebrewscriptfont", i18n)}
+                        label={doI18n("pages:core-settings:select_hebrewscriptfont", i18n)}
                         onChange={handleChangeHebrew}
                         sx={sx.select}
                     >
@@ -235,7 +236,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
             <Box sx={{minWidth: 185}}>
                 <FormControl fullWidth style={{maxWidth: 300}} size="small">
                     <InputLabel id="select-myanmar-font-label" htmlFor="select-myanmar-font-id" sx={sx.inputLabel}>
-                      {doI18n("pages:core-client-settings:select_myanmarscriptfont", i18n)}
+                      {doI18n("pages:core-settings:select_myanmarscriptfont", i18n)}
                     </InputLabel>
                     <Select
                         variant="outlined"
@@ -245,7 +246,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
                             id: "select-myanmar-font-id",
                         }}
                         value={myanmar}
-                        label={doI18n("pages:core-client-settings:select_myanmarscriptfont", i18n)}
+                        label={doI18n("pages:core-settings:select_myanmarscriptfont", i18n)}
                         onChange={handleChangeMyanmar}
                         sx={sx.select}
                     >
@@ -260,7 +261,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
             <Box sx={{minWidth: 275}}>
                 <FormControl fullWidth style={{maxWidth: 300}} size="small">
                     <InputLabel id="select-arabic-urdu-font-label" htmlFor="select-arabic-urdu-font-id" sx={sx.inputLabel}>
-                      {doI18n("pages:core-client-settings:select_arabicurduscriptfont", i18n)}
+                      {doI18n("pages:core-settings:select_arabicurduscriptfont", i18n)}
                     </InputLabel>
                     <Select
                         variant="outlined"
@@ -270,13 +271,13 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
                             id: "select-arabic-urdu-font-id",
                         }}
                         value={arabicUrdu}
-                        label={doI18n("pages:core-client-settings:select_arabicurduscriptfont", i18n)}
+                        label={doI18n("pages:core-settings:select_arabicurduscriptfont", i18n)}
                         onChange={handleChangeArabicUrdu}
                         sx={sx.select}
                     >
                       {WebFontsSelectableArabicUrdu}
                     </Select>
-                    <FormHelperText>{doI18n("pages:core-client-settings:replaceawamiifnotfirefox", i18n)}</FormHelperText>
+                    <FormHelperText>{doI18n("pages:core-settings:replaceawamiifnotfirefox", i18n)}</FormHelperText>
                 </FormControl>
             </Box>
         </div>
@@ -286,7 +287,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
             <Box sx={{minWidth: 200}}>
                 <FormControl fullWidth style={{maxWidth: 300}} size="small">
                     <InputLabel id="select-other-font-label" htmlFor="select-other-font-id" sx={sx.inputLabel}>
-                      {doI18n("pages:core-client-settings:select_otherscriptfont", i18n)}
+                      {doI18n("pages:core-settings:select_otherscriptfont", i18n)}
                     </InputLabel>
                     <Select
                         variant="outlined"
@@ -296,7 +297,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
                             id: "select-other-font-id",
                         }}
                         value={other}
-                        label={doI18n("pages:core-client-settings:select_otherscriptfont", i18n)}
+                        label={doI18n("pages:core-settings:select_otherscriptfont", i18n)}
                         onChange={handleChangeOther}
                         sx={sx.select}
                     >
@@ -311,7 +312,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
             <Box sx={{minWidth: 225}}>
                 <FormControl fullWidth style={{maxWidth: 300}} size="small">
                     <InputLabel id="select-fallback-font-label" htmlFor="select-fallback-font-id" sx={sx.inputLabel}>
-                      {doI18n("pages:core-client-settings:select_fallbackscriptfont", i18n)}
+                      {doI18n("pages:core-settings:select_fallbackscriptfont", i18n)}
                     </InputLabel>
                     <Select
                         variant="outlined"
@@ -321,7 +322,7 @@ export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps
                             id: "select-fallback-font-id",
                         }}
                         value={fallback}
-                        label={doI18n("pages:core-client-settings:select_fallbackscriptfont", i18n)}
+                        label={doI18n("pages:core-settings:select_fallbackscriptfont", i18n)}
                         onChange={handleChangeFallback}
                         sx={sx.select}
                     >

--- a/src/components/PithekosToolbarSelectFont.jsx
+++ b/src/components/PithekosToolbarSelectFont.jsx
@@ -1,0 +1,343 @@
+import {useEffect, useContext, useState} from "react";
+import {Grid2, FormHelperText, Box, InputLabel, MenuItem, FormControl, Select} from "@mui/material";
+import FontMenuItem from "./FontMenuItem";
+import sx from "./PithekosToolbar.styles";
+import PropTypes from 'prop-types';
+import {i18nContext as I18nContext, doI18n } from "pithekos-lib";
+
+export default function PithekosToolbarSelectFont(PithekosToolbarSelectFontProps) {
+  const i18n = useContext(I18nContext);
+  const {
+      activeFontClass,
+      setSelectedFontClass,
+      selectedHebrewFontClass,
+      setSelectedHebrewFontClass,
+      selectedMyanmarFontClass,
+      setSelectedMyanmarFontClass,
+      selectedArabicUrduFontClass,
+      setSelectedArabicUrduFontClass,
+      selectedOtherFontClass,
+      setSelectedOtherFontClass,
+      selectedFallbackFontClass,
+      setSelectedFallbackFontClass,
+  } = PithekosToolbarSelectFontProps;
+
+  const [activeHebrewFontClass, setActiveHebrewFontClass] = useState('');
+  const [activeMyanmarFontClass, setActiveMyanmarFontClass] = useState('');
+  const [activeArabicUrduFontClass, setActiveArabicUrduFontClass] = useState('');
+  const [activeOtherFontClass, setActiveOtherFontClass] = useState('');
+  const [activeFallbackFontClass, setActiveFallbackFontClass] = useState('');
+  const [hebrewSelected, setHebrewSelected] = useState(false);
+  const [myanmarSelected, setMyanmarSelected] = useState(false);
+  const [arabicUrduSelected, setArabicUrduSelected] = useState(false);
+  const [otherSelected, setOtherSelected] = useState(false);
+  const [fallbackSelected, setFallbackSelected] = useState(false);
+  
+  useEffect ( () => {
+    const webFontsHebrew = [
+      { name: 'Ezra SIL 2.51', id: 'Pankosmia-EzraSIL' },
+      { name: 'Ezra SIL SR 2.51', id: 'Pankosmia-EzraSILSR' },
+      { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+    ];
+  
+    const webFontsMyanmar = [
+      { name: 'Padauk 5.100', id: 'Pankosmia-Padauk' },
+      { name: 'Padauk Book 5.100', id: 'Pankosmia-PadaukBook' },
+      { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+    ];
+  
+    const webFontsArabicUrdu = [
+      { name: 'Awami Nastaliq 3.300*', id: 'Pankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrdu' },
+      { name: 'Awami Nastaliq Medium 3.300*', id: 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu' },
+      { name: 'Awami Nastaliq Semi Bold 3.300*', id: 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu' },
+      { name: 'Awami Nastaliq Extra Bold 3.300*', id: 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu' },
+      { name: 'Noto Naskh Arabic 2022', id: 'Pankosmia-NotoNaskhArabic' },
+      { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+    ];
+    
+    const webFontsOther = [
+      { name: 'Andika 6.200', id: 'Pankosmia-Andika' },
+      { name: 'Cardo 2011', id: 'Pankosmia-Cardo' },
+      { name: 'Charis SIL 6.200', id: 'Pankosmia-CharisSIL' },
+      { name: 'Open Sans 2020', id: 'Pankosmia-OpenSans' },
+      { name: 'Roboto 2004', id: 'Pankosmia-Roboto' },
+      { name: 'Roboto Black 2004', id: 'Pankosmia-RobotoBlack' },
+      { name: 'Roboto Light 2004', id: 'Pankosmia-RobotoLight' },
+      { name: 'Roboto Medium 2004', id: 'Pankosmia-RobotoMedium' },
+      { name: 'Roboto Thin 2004', id: 'Pankosmia-RobotoThin' },
+      { name: '- ' + doI18n("pages:core-client-settings:fallback", i18n) + ' -', id: '' },
+    ];
+  
+    const webFontsFallback = [
+      { name: 'Gentium Plus 6.200', id: 'Pankosmia-GentiumPlus' },
+      { name: 'Gentium Book Plus 6.200', id: 'Pankosmia-GentiumBookPlus' },
+    ];
+
+    const fontClassIds = (activeFontClass !== undefined ? activeFontClass.replace(/Pankosmia-/g,'~Pankosmia-').split('~') : []);
+
+    const webFontsHebrewIds = webFontsHebrew.map((font, index) => (font.id));
+    const activeHebrewId = fontClassIds.filter(item => webFontsHebrewIds.includes(item));
+    setActiveHebrewFontClass(activeHebrewId);
+
+    const webFontsMyanmarIds = webFontsMyanmar.map((font, index) => (font.id));
+    const activeMyanmarId = fontClassIds.filter(item => webFontsMyanmarIds.includes(item));
+    setActiveMyanmarFontClass(activeMyanmarId);
+
+    const webFontsArabicUrduIds = webFontsArabicUrdu.map((font, index) => (font.id));
+    const fontClassAwamiToAdj = fontClassIds.filter(item => item.includes('AwamiNastaliq'));
+    const activeArabicUrduId = (fontClassAwamiToAdj !== '' ? fontClassAwamiToAdj + 'Pankosmia-NotoNastaliqUrdu' : fontClassIds.filter(item => webFontsArabicUrduIds.includes(item)));
+    setActiveArabicUrduFontClass(activeArabicUrduId);
+
+    const webFontsOtherIds = webFontsOther.map((font, index) => (font.id));
+    const activeOtherId = fontClassIds.filter(item => webFontsOtherIds.includes(item));
+    setActiveOtherFontClass(activeOtherId);
+
+    const webFontsFallbackIds = webFontsFallback.map((font, index) => (font.id));
+    const activeFallbackId = fontClassIds.filter(item => webFontsFallbackIds.includes(item));
+    setActiveFallbackFontClass(activeFallbackId);
+  },[activeFontClass, i18n])
+
+  const hebrew = hebrewSelected ? selectedHebrewFontClass : activeHebrewFontClass;
+  const myanmar = myanmarSelected ? selectedMyanmarFontClass : activeMyanmarFontClass;
+  const arabicUrdu = arabicUrduSelected ? selectedArabicUrduFontClass : activeArabicUrduFontClass;
+  const other = otherSelected ? selectedOtherFontClass : activeOtherFontClass;
+  const fallback = fallbackSelected ? selectedFallbackFontClass : activeFallbackFontClass;
+
+  const handleChangeHebrew = (event) => {
+    setHebrewSelected(true);
+    setSelectedHebrewFontClass(event.target.value);
+    setSelectedFontClass('fonts-' + event.target.value + myanmar + arabicUrdu + other + fallback);
+  };
+  const handleChangeMyanmar = (event) => {
+    setMyanmarSelected(true);
+    setSelectedMyanmarFontClass(event.target.value);
+    setSelectedFontClass('fonts-' + hebrew + event.target.value + arabicUrdu + other + fallback);
+  };
+  const handleChangeArabicUrdu = (event) => {
+    setArabicUrduSelected(true);
+    setSelectedArabicUrduFontClass(event.target.value);
+    setSelectedFontClass('fonts-' + hebrew + myanmar + event.target.value + other + fallback);
+  };
+  const handleChangeOther = (event) => {
+    setOtherSelected(true);
+    setSelectedOtherFontClass(event.target.value);
+    setSelectedFontClass('fonts-' + hebrew + myanmar + arabicUrdu + event.target.value + fallback);
+  };
+  const handleChangeFallback = (event) => {
+    setFallbackSelected(true);
+    setSelectedFallbackFontClass(event.target.value);
+    setSelectedFontClass('fonts-' + hebrew + myanmar + arabicUrdu + other + event.target.value);
+  };
+
+  const webFontsSelectableHebrew = [
+    { name: 'Ezra SIL 2.51', id: 'Pankosmia-EzraSIL' },
+    { name: 'Ezra SIL SR 2.51', id: 'Pankosmia-EzraSILSR' },
+    { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+  ];
+
+  const webFontsSelectableMyanmar = [
+    { name: 'Padauk 5.100', id: 'Pankosmia-Padauk' },
+    { name: 'Padauk Book 5.100', id: 'Pankosmia-PadaukBook' },
+    { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+  ];
+
+  const webFontsSelectableArabicUrdu = [
+    { name: 'Awami Nastaliq 3.300*', id: 'Pankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrdu' },
+    { name: 'Awami Nastaliq Medium 3.300*', id: 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu' },
+    { name: 'Awami Nastaliq Semi Bold 3.300*', id: 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu' },
+    { name: 'Awami Nastaliq Extra Bold 3.300*', id: 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu' },
+    { name: 'Noto Naskh Arabic 2022', id: 'Pankosmia-NotoNaskhArabic' },
+    { name: '- ' + doI18n("pages:core-client-settings:other-fallback", i18n) + ' -', id: '' },
+  ];
+  
+  const webFontsSelectableOther = [
+    { name: 'Andika 6.200', id: 'Pankosmia-Andika' },
+    { name: 'Cardo 2011', id: 'Pankosmia-Cardo' },
+    { name: 'Charis SIL 6.200', id: 'Pankosmia-CharisSIL' },
+    { name: 'Open Sans 2020', id: 'Pankosmia-OpenSans' },
+    { name: 'Roboto 2004', id: 'Pankosmia-Roboto' },
+    { name: 'Roboto Black 2004', id: 'Pankosmia-RobotoBlack' },
+    { name: 'Roboto Light 2004', id: 'Pankosmia-RobotoLight' },
+    { name: 'Roboto Medium 2004', id: 'Pankosmia-RobotoMedium' },
+    { name: 'Roboto Thin 2004', id: 'Pankosmia-RobotoThin' },
+    { name: '- ' + doI18n("pages:core-client-settings:fallback", i18n) + ' -', id: '' },
+  ];
+
+  const webFontsSelectableFallback = [
+    { name: 'Gentium Plus 6.200', id: 'Pankosmia-GentiumPlus' },
+    { name: 'Gentium Book Plus 6.200', id: 'Pankosmia-GentiumBookPlus' },
+  ];
+
+  const WebFontsSelectableHebrew =
+    webFontsSelectableHebrew.map((font, index) => (
+        <MenuItem key={index} value={font.id} dense>
+            <FontMenuItem font={font}/>
+        </MenuItem>
+    ));
+
+  const WebFontsSelectableMyanmar =
+    webFontsSelectableMyanmar.map((font, index) => (
+        <MenuItem key={index} value={font.id} dense>
+            <FontMenuItem font={font}/>
+        </MenuItem>
+    ));
+
+  const WebFontsSelectableArabicUrdu =
+    webFontsSelectableArabicUrdu.map((font, index) => (
+        <MenuItem key={index} value={font.id} dense>
+            <FontMenuItem font={font}/>
+        </MenuItem>
+    ));
+
+  const WebFontsSelectableOther =
+    webFontsSelectableOther.map((font, index) => (
+        <MenuItem key={index} value={font.id} dense>
+            <FontMenuItem font={font}/>
+        </MenuItem>
+    ));
+
+  const WebFontsSelectableFallback =
+    webFontsSelectableFallback.map((font, index) => (
+        <MenuItem key={index} value={font.id} dense>
+            <FontMenuItem font={font}/>
+        </MenuItem>
+    ));
+
+  return (
+    <Grid2 container spacing={2}>
+      <Grid2>
+        <div item style={{maxWidth: 170, padding: "1.25em 0"}}>
+            <Box sx={{minWidth: 170}}>
+                <FormControl fullWidth style={{maxWidth: 300}} size="small">
+                    <InputLabel id="select-hebrew-font-label" htmlFor="select-hebrew-font-id" sx={sx.inputLabel}>
+                      {doI18n("pages:core-client-settings:select_hebrewscriptfont", i18n)}
+                    </InputLabel>
+                    <Select
+                        variant="outlined"
+                        labelId="select-hebrew-font-label"
+                        name="select-hebrew-font-name"
+                        inputProps={{
+                            id: "select-hebrew-font-id",
+                        }}
+                        value={hebrew}
+                        label={doI18n("pages:core-client-settings:select_hebrewscriptfont", i18n)}
+                        onChange={handleChangeHebrew}
+                        sx={sx.select}
+                    >
+                      {WebFontsSelectableHebrew}
+                    </Select>
+                </FormControl>
+            </Box>
+        </div>
+      </Grid2>
+      <Grid2>
+        <div item style={{maxWidth: 185, padding: "1.25em 0"}}>
+            <Box sx={{minWidth: 185}}>
+                <FormControl fullWidth style={{maxWidth: 300}} size="small">
+                    <InputLabel id="select-myanmar-font-label" htmlFor="select-myanmar-font-id" sx={sx.inputLabel}>
+                      {doI18n("pages:core-client-settings:select_myanmarscriptfont", i18n)}
+                    </InputLabel>
+                    <Select
+                        variant="outlined"
+                        labelId="select-myanmar-font-label"
+                        name="select-myanmar-font-name"
+                        inputProps={{
+                            id: "select-myanmar-font-id",
+                        }}
+                        value={myanmar}
+                        label={doI18n("pages:core-client-settings:select_myanmarscriptfont", i18n)}
+                        onChange={handleChangeMyanmar}
+                        sx={sx.select}
+                    >
+                      {WebFontsSelectableMyanmar}
+                    </Select>
+                </FormControl>
+            </Box>
+        </div>
+      </Grid2>
+      <Grid2>
+        <div item style={{maxWidth: 275, padding: "1.25em 0 0 0"}}>
+            <Box sx={{minWidth: 275}}>
+                <FormControl fullWidth style={{maxWidth: 300}} size="small">
+                    <InputLabel id="select-arabic-urdu-font-label" htmlFor="select-arabic-urdu-font-id" sx={sx.inputLabel}>
+                      {doI18n("pages:core-client-settings:select_arabicurduscriptfont", i18n)}
+                    </InputLabel>
+                    <Select
+                        variant="outlined"
+                        labelId="select-arabic-urdu-font-label"
+                        name="select-arabic-urdu-font-name"
+                        inputProps={{
+                            id: "select-arabic-urdu-font-id",
+                        }}
+                        value={arabicUrdu}
+                        label={doI18n("pages:core-client-settings:select_arabicurduscriptfont", i18n)}
+                        onChange={handleChangeArabicUrdu}
+                        sx={sx.select}
+                    >
+                      {WebFontsSelectableArabicUrdu}
+                    </Select>
+                    <FormHelperText>{doI18n("pages:core-client-settings:replaceawamiifnotfirefox", i18n)}</FormHelperText>
+                </FormControl>
+            </Box>
+        </div>
+      </Grid2>
+      <Grid2>
+        <div item style={{maxWidth: 200, padding: "1.25em 0"}}>
+            <Box sx={{minWidth: 200}}>
+                <FormControl fullWidth style={{maxWidth: 300}} size="small">
+                    <InputLabel id="select-other-font-label" htmlFor="select-other-font-id" sx={sx.inputLabel}>
+                      {doI18n("pages:core-client-settings:select_otherscriptfont", i18n)}
+                    </InputLabel>
+                    <Select
+                        variant="outlined"
+                        labelId="select-other-font-label"
+                        name="select-other-font-name"
+                        inputProps={{
+                            id: "select-other-font-id",
+                        }}
+                        value={other}
+                        label={doI18n("pages:core-client-settings:select_otherscriptfont", i18n)}
+                        onChange={handleChangeOther}
+                        sx={sx.select}
+                    >
+                      {WebFontsSelectableOther}
+                    </Select>
+                </FormControl>
+            </Box>
+        </div>
+      </Grid2>
+      <Grid2>
+        <div item style={{maxWidth: 225, padding: "1.25em 0"}}>
+            <Box sx={{minWidth: 225}}>
+                <FormControl fullWidth style={{maxWidth: 300}} size="small">
+                    <InputLabel id="select-fallback-font-label" htmlFor="select-fallback-font-id" sx={sx.inputLabel}>
+                      {doI18n("pages:core-client-settings:select_fallbackscriptfont", i18n)}
+                    </InputLabel>
+                    <Select
+                        variant="outlined"
+                        labelId="select-fallback-font-label"
+                        name="select-fallback-font-name"
+                        inputProps={{
+                            id: "select-fallback-font-id",
+                        }}
+                        value={fallback}
+                        label={doI18n("pages:core-client-settings:select_fallbackscriptfont", i18n)}
+                        onChange={handleChangeFallback}
+                        sx={sx.select}
+                    >
+                      {WebFontsSelectableFallback}
+                    </Select>
+                </FormControl>
+            </Box>
+        </div>
+      </Grid2>
+    </Grid2>
+  );
+}
+
+PithekosToolbarSelectFont.propTypes = {
+    /** Selected Font Set CSS Name */
+    selectedFontClass: PropTypes.string,
+    /** Set Selected Font Set CSS Name */
+    setSelectedFontClass: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
### Cordinated PR:

This PR needs to be applied in conjunction with:

- panksomia/core-client-workspace: [run/blended_fonts](https://github.com/pankosmia/core-client-workspace/pull/1)
- panksomia/pankosmia-web:  [run/blended_fonts](https://github.com/pankosmia/pankosmia-web/pull/1)
- panksomia/pithekos:  [run/blended_fonts](https://github.com/pankosmia/pithekos/pull/2)

Apply all 4 of these PR's before starting a server from pankosmia-web or pithekos.

### Highlights
- Fonts are set in one place for all workspaces.
- Hebrew, Myanmar, and Arabic/Urdu webfonts are only applied to respective unicode ranges.
- Awami Nastaliq only loads in Firefox. As it is non-sensical without Graphite, the Arabic/Urdu unicode range falls back to Noto Nastaliq Urdu when Awami Nastaliq is not loaded (e.g., the browser is not Firefox).
- While Padauk renders best in Firefox (Graphite) it is still shown all browsers when applied.
- Duplicate were previously preventing some variations from displaying in a few cases. This has been corrected.

### Testing
1. Go to settings.  The active font_set will be shown.
2. Make changes using the dropdowns.
3. Make the indicated change in user_settings.json
4. Restart the server, and note the changes in effect. Use the editing area to type or paste in characters to test if not pulling in resources with them.

- Of note: Be sure to have text from each script set on the screen at the same time to see the fonts by unicode range in effect.
