### PR TITLE
Fallback Language Settings

### DIFF
--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -8,59 +8,73 @@
   "i18n": {
     "title": {
       "en": "Settings",
-      "fr": "Paramètres"
+      "fr": "Paramètres",
+      "id": "Pengaturan"
     },
     "summary": {
       "en": "Settings for languages, debugging, data sources...",
-      "fr": "Configuration (langues, déboguage, sources de données...)"
+      "fr": "Configuration (langues, déboguage, sources de données...)",
+      "id": "Pengaturan untuk bahasa, menemukan kesalahan program, sumber data, dll."
     },
     "debug_prompt": {
       "en": "Debug?",
-      "fr": "Débogage ?"
+      "fr": "Débogage ?",
+      "id": "Debug?"
     },
     "fonts": {
       "en": "Fonts",
-      "fr": "Polices"
+      "fr": "Polices",
+      "id": "Fon-fon"
     },
     "language": {
       "en": "Language",
-      "fr": "Langue"
+      "fr": "Langue",
+      "id": "Bahasa"
     },
     "select_hebrewscriptfont": {
       "en": "Hebrew Script Font",
-      "fr": "Police pour Hébreu"
+      "fr": "Police pour Hébreu",
+      "id": "Fon Aksara Ibrani"
     },
     "select_greekscriptfont": {
       "en": "Greek Script Font",
-      "fr": "Police pour Grec"
+      "fr": "Police pour Grec",
+      "id": "Fon Aksara Yunani"
     },
     "select_myanmarscriptfont": {
       "en": "Myanmar / Kayah Li Script Font",
-      "fr": "Police pour Myanmar / Kayah Li"
+      "fr": "Police pour Myanmar / Kayah Li",
+      "id": "Fon Aksara Myanmar / Kayah Li"
     },
     "select_arabicurduscriptfont": {
-      "en": "Arabic/Urdu Script Font",
-      "fr": "Police pour Arabe / Ourdou"
+      "en": "Arabic / Urdu Script Font",
+      "fr": "Police pour Arabe / Ourdou",
+      "id": "Fon Aksara Arab / Urdu"
     },
     "select_otherscriptfont": {
       "en": "Other Script Font",
-      "fr": "Police supplémentaire"
+      "fr": "Police supplémentaire",
+      "id": "Fon Aksara Lain"
     },
     "select_fallbackscriptfont": {
       "en": "Base Script Font",
-      "fr": "Police de base"
+      "fr": "Police de base",
+      "id": "Fon Aksara Dasar"
     },
     "other-fallback": {
-      "en": "Other/Fallback",
-      "fr": "Autre / Police de base"
+      "en": "Other / Fallback",
+      "fr": "Autre / Police de base",
+      "id": "Lainnya / Terakhir"
     },
     "fallback": {
       "en": "Fallback",
-      "fr": "Police de base"
+      "fr": "Police de base",
+      "id": "Terakhir"
     },
     "replaceawamiifnotfirefox": {
       "en": "* Noto Nastaliq Urdu 4.000 if browser is not Firefox",
-      "fr": "* Noto Nastaliq Urdu 4.000 si navigateur n'est pas Firefox"
+      "fr": "* Noto Nastaliq Urdu 4.000 si navigateur n'est pas Firefox",
+      "id": "* Noto Nastaliq Urdu 4.000 ketika peramban web bukan Firefox"
     }
   }
 }

--- a/src/components/LanguageMenuItem.jsx
+++ b/src/components/LanguageMenuItem.jsx
@@ -32,6 +32,6 @@ export default function LanguageMenuItem(languageMenuItemProps) {
 
 LanguageMenuItem.propTypes = {
   languageId: PropTypes.shape({
-    index: PropTypes.string,
+    index: PropTypes.objectOf(PropTypes.string),
   }),
 };

--- a/src/components/LanguageSelection.jsx
+++ b/src/components/LanguageSelection.jsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 
-import { Grid2, Box, InputLabel, FormControl, Select, MenuItem } from "@mui/material";
+import { Grid2, Box, InputLabel, FormControl, Select, MenuItem, Stack } from "@mui/material";
+import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
 import { i18nContext, doI18n, getAndSetJson, postEmptyJson} from "pithekos-lib";
 import sx from "./Selection.styles";
 import LanguageMenuItem from "./LanguageMenuItem";
@@ -9,7 +10,13 @@ export default function LanguageSelection() {
 
   const i18n = useContext(i18nContext);
   const [usedEndonyms, setUsedEndonyms] = useState([]);
-  const [selectedLanguage, setSelectedLanguage] = useState('');
+  const [secondUsedEndonyms, setSecondUsedEndonyms] = useState([]);
+  const [thirdUsedEndonyms, setThirdUsedEndonyms] = useState([]);
+  const [selectedLanguages, setSelectedLanguages] = useState('');
+  const [firstSelectedLanguage, setFirstSelectedLanguage] = useState('');
+  const [secondSelectedLanguage, setSecondSelectedLanguage] = useState('');
+  const [thirdSelectedLanguage, setThirdSelectedLanguage] = useState('');
+  const [fourthSelectedLanguage, setFourthSelectedLanguage] = useState('');
   const [usedLanguages, setUsedLanguages] = useState([]);
   useEffect(
     () => {
@@ -19,8 +26,8 @@ export default function LanguageSelection() {
         }).then()
         getAndSetJson({
           url: "/settings/languages",
-          setter: setSelectedLanguage
-      }).then()},
+          setter: setSelectedLanguages
+        }).then()},
     []
   );
 
@@ -83,6 +90,7 @@ export default function LanguageSelection() {
       { id: 'ka', endonym: 'ქართული (Kharthuli)' },
       { id: 'de', endonym: 'Deutsch' },
       { id: 'el', endonym: 'Νέα Ελληνικά; (Néa Ellêniká)' },
+      { id: 'grc', endonym: 'Ἑλλάς'},
       { id: 'gn', endonym: 'Avañe\'ẽ' },
       { id: 'gu', endonym: 'ગુજરાતી (Gujarātī)' },
       { id: 'ht', endonym: 'Kreyòl ayisyen' },
@@ -216,9 +224,56 @@ export default function LanguageSelection() {
   
   },[usedLanguages]);
 
-  const handleChangeLanguage = (event) => {
-    setSelectedLanguage(event.target.value);
-    postEmptyJson('/settings/languages/' + event.target.value);
+  useEffect( () => {
+    setSecondUsedEndonyms(usedEndonyms.filter(item => (item.id !== firstSelectedLanguage)));
+    setThirdUsedEndonyms(usedEndonyms.filter(item => ((item.id !== firstSelectedLanguage) && (item.id !== secondSelectedLanguage))));
+  },[firstSelectedLanguage, secondSelectedLanguage, usedEndonyms]);
+
+  useEffect(() => {
+    setFirstSelectedLanguage(selectedLanguages[0]);
+    setSecondSelectedLanguage(selectedLanguages[1]);
+    setThirdSelectedLanguage(selectedLanguages[2]);
+    setFourthSelectedLanguage(selectedLanguages[3]);
+  },[selectedLanguages]);
+  
+  const handleFirstChangeLanguage = (event) => {
+    const addEn = ((event.target.value !== 'en') && (secondSelectedLanguage !== 'en') && (thirdSelectedLanguage !== 'en') ? '/en' : '')
+    const fallbackLanguages = (secondSelectedLanguage !== undefined ? '/' + secondSelectedLanguage : '') + (thirdSelectedLanguage !== undefined ? '/' + thirdSelectedLanguage : '')
+    const postLanguage = event.target.value + fallbackLanguages.replace('/' + event.target.value, '') + addEn;
+    postLanguageId(postLanguage);
+  };
+
+  const handleSecondChangeLanguage = (event) => {
+    const addEn = ((firstSelectedLanguage !== 'en') && (event.target.value !== 'en') && (thirdSelectedLanguage !== 'en') ? '/en' : '')
+    const fallbackLanguages = (thirdSelectedLanguage !== undefined ? '/' + thirdSelectedLanguage : '')
+    const postLanguage = firstSelectedLanguage + '/' + event.target.value + fallbackLanguages.replace('/' + event.target.value, '') + addEn;
+    postLanguageId(postLanguage);
+  };
+
+  const handleThirdChangeLanguage = (event) => {
+    const addEn = ((firstSelectedLanguage !== 'en') && (secondSelectedLanguage !== 'en') && (event.target.value !== 'en') ? '/en' : '')
+    const second = (secondSelectedLanguage !== undefined ? '/' + secondSelectedLanguage : '')
+    const postLanguage = firstSelectedLanguage + second + '/' + event.target.value + addEn;
+    postLanguageId(postLanguage);
+  };
+
+  const handleRemoveFirstLanguage = (event) => {
+    const postLanguage = secondSelectedLanguage + (thirdSelectedLanguage !== undefined ? '/' + thirdSelectedLanguage : '') + (fourthSelectedLanguage !== undefined ? '/' + fourthSelectedLanguage : '')
+    postLanguageId(postLanguage);
+  };
+
+  const handleRemoveSecondLanguage = (event) => {
+    const postLanguage = firstSelectedLanguage + (thirdSelectedLanguage !== undefined ? '/' + thirdSelectedLanguage : '') + (fourthSelectedLanguage !== undefined ? '/' + fourthSelectedLanguage : '')
+    postLanguageId(postLanguage);
+  };
+
+  const handleRemoveThirdLanguage = (event) => {
+    const postLanguage = firstSelectedLanguage + '/' + secondSelectedLanguage + (fourthSelectedLanguage !== undefined ? '/' + fourthSelectedLanguage : '')
+    postLanguageId(postLanguage);
+  };
+
+  const postLanguageId = async (iD) => { 
+    await postEmptyJson('/settings/languages/' + iD);
     window.location.reload(false);
   };
 
@@ -229,12 +284,25 @@ export default function LanguageSelection() {
             <LanguageMenuItem language={language}/>
         </MenuItem>
   ));
+  const SecondUsedEndonyms =
+  secondUsedEndonyms.map((language, index) => (
+      <MenuItem key={index} value={language.id} dense>
+          <LanguageMenuItem language={language}/>
+      </MenuItem>
+  ));
+  const ThirdUsedEndonyms =
+  thirdUsedEndonyms.map((language, index) => (
+      <MenuItem key={index} value={language.id} dense>
+          <LanguageMenuItem language={language}/>
+      </MenuItem>
+  ));
 
   return (
     <Grid2 container spacing={2}>
       <Grid2 size={12} sx={{ borderTop: 1, borderColor: 'purple' }}>
         <div item style={{padding: "1.25em 0 0 0"}}>
             <Box>
+              <Stack direction="row">
                 <FormControl size="small">
                     <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
                       {doI18n("pages:core-settings:language", i18n)}
@@ -246,17 +314,79 @@ export default function LanguageSelection() {
                         inputProps={{
                             id: "select-language",
                         }}
-                        value={selectedLanguage}
+                        value={firstSelectedLanguage}
                         label={doI18n("pages:core-settings:language", i18n)}
-                        onChange={handleChangeLanguage}
+                        onChange={handleFirstChangeLanguage}
                         sx={sx.select}
                     >
                       {UsedEndonyms}
                     </Select>
                 </FormControl>
+                {firstSelectedLanguage !== 'en' && <RemoveCircleIcon style={{ color: "purple" }} onClick={handleRemoveFirstLanguage}  />}
+              </Stack>
             </Box>
         </div>
       </Grid2>
+      {secondSelectedLanguage !== undefined &&
+        <Grid2 size={12} sx={{ borderTop: 1, borderColor: 'purple' }}>
+          <div item style={{padding: "1.25em 0 0 0"}}>
+              <Box>
+                <Stack direction="row">
+                  <FormControl size="small">
+                      <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
+                        {doI18n("pages:core-settings:language", i18n)}
+                      </InputLabel>
+                      <Select
+                          variant="outlined"
+                          labelId="select-language-label"
+                          name="select-language"
+                          inputProps={{
+                              id: "select-language",
+                          }}
+                          value={secondSelectedLanguage}
+                          label={doI18n("pages:core-settings:language", i18n)}
+                          onChange={handleSecondChangeLanguage}
+                          sx={sx.select}
+                      >
+                        {SecondUsedEndonyms}
+                      </Select>
+                  </FormControl>
+                  {secondSelectedLanguage !== 'en' && <RemoveCircleIcon style={{ color: "purple" }} onClick={handleRemoveSecondLanguage}  />}
+                </Stack>
+              </Box>
+          </div>
+        </Grid2>
+      }
+      {thirdSelectedLanguage !== undefined &&
+        <Grid2 size={12} sx={{ borderTop: 1, borderColor: 'purple' }}>
+          <div item style={{padding: "1.25em 0 0 0"}}>
+              <Box>
+                <Stack direction="row">
+                  <FormControl size="small">
+                      <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
+                        {doI18n("pages:core-settings:language", i18n)}
+                      </InputLabel>
+                      <Select
+                          variant="outlined"
+                          labelId="select-language-label"
+                          name="select-language"
+                          inputProps={{
+                              id: "select-language",
+                          }}
+                          value={thirdSelectedLanguage}
+                          label={doI18n("pages:core-settings:language", i18n)}
+                          onChange={handleThirdChangeLanguage}
+                          sx={sx.select}
+                      >
+                        {ThirdUsedEndonyms}
+                      </Select>
+                  </FormControl>
+                  {thirdSelectedLanguage !== 'en' && <RemoveCircleIcon style={{ color: "purple" }} onClick={handleRemoveThirdLanguage} />}
+                </Stack>
+              </Box>
+          </div>
+        </Grid2>
+      }
     </Grid2>
   );
 }


### PR DESCRIPTION
### How this works:
- If 1st preferred language is 'en', then there will be only one dropdown. 
![image](https://github.com/user-attachments/assets/1050083c-47be-4960-af79-d343855bb3fb)
  - _(Unless other fallback languages were previously configured, in which case another dropdown or two will continue to appear.)_
  ![image](https://github.com/user-attachments/assets/286bae29-f3b4-4b21-91e1-20f621155baa)
- If there is only one dropdown and the 1st preferred language is set to something other than 'en', that will load a 2nd dropdown defaulted to 'en', which can be changed to any used language except for the 1st preferred language.
![image](https://github.com/user-attachments/assets/e9194743-6c46-4774-aef9-079a5852513d)
- If there are only 2 dropdowns and the 2nd preferred language is set to something other than 'en', that will load a 3rd dropdown defaulted to 'en', which can be changed to any used language except for the 1st or 2nd preferred languages.
![image](https://github.com/user-attachments/assets/2c3963dd-eb4d-47cd-a0d0-d959c3261b02)
- If a language other than en is selected in the 3rd dropdown, then 'en' will quietly be added to the 4th fallback slot.
![image](https://github.com/user-attachments/assets/0121e0ef-1de9-4b46-8da3-be7fa32701ff)
![image](https://github.com/user-attachments/assets/c9ab275a-fba5-4216-9c59-1acb64d63332)
- If the 1st preference is changes to a language that is already included as the 2nd, 3rd, or 4th preference, then that other lower preference will be removed and the other languages will be moved up one in preference order as applicable.
  - _Try this to see it.!_
 
### Tips:
- To get the 1st language preference to become a selectable 2nd language option, simply select a different 1st language.
- To get the 1st or 2nd language preferences to become a selectable 3rd language option, simply select a different 1st or 2nd language preference.
- Remove buttons are provided on dropdowns when they are displayed and are not set to 'en'.

### Testing:
1. Open two windows. Point one to [Settings](http://localhost:8000/clients/settings) and the other to [Language Settings](http://localhost:8000/settings/languages).
2. Make changes in [Settings](http://localhost:8000/clients/settings) then refresh [Language Settings](http://localhost:8000/settings/languages) to confirm.