### PR TITLE
MVH's recursive selection merged

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dompurify": "^3.2.4",
         "eslint-config-react-app": "^7.0.1",
         "font-detect-rhl": "^1.1.7",
-        "pithekos-lib": "^0.5.11",
+        "pithekos-lib": "^0.5.24",
         "prop-types": "^15.8.1",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
@@ -14648,9 +14648,9 @@
       }
     },
     "node_modules/pithekos-lib": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/pithekos-lib/-/pithekos-lib-0.5.11.tgz",
-      "integrity": "sha512-dsHGyMamn8qq6ZzC/xGK6kolYa2ltysQgnoJyynK0cFP3Ju0g/NIwp28Oq90PES/ecUDdnVmE5GIq3U1avmNog==",
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/pithekos-lib/-/pithekos-lib-0.5.24.tgz",
+      "integrity": "sha512-DrL8HZhAMTGEtJoP02ucCdpbuBajoJ1lBUeRm+q/pUyVxK5BqOGX2SxLD0YGi1Jt9B7o9Wve2NbE/Xxae5X/2A==",
       "dependencies": {
         "@babel/cli": "^7.24.8",
         "@babel/core": "^7.24.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dompurify": "^3.2.4",
         "eslint-config-react-app": "^7.0.1",
         "font-detect-rhl": "^1.1.7",
-        "pithekos-lib": "^0.5.24",
+        "pithekos-lib": "^0.6.0",
         "prop-types": "^15.8.1",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
@@ -14648,9 +14648,9 @@
       }
     },
     "node_modules/pithekos-lib": {
-      "version": "0.5.24",
-      "resolved": "https://registry.npmjs.org/pithekos-lib/-/pithekos-lib-0.5.24.tgz",
-      "integrity": "sha512-DrL8HZhAMTGEtJoP02ucCdpbuBajoJ1lBUeRm+q/pUyVxK5BqOGX2SxLD0YGi1Jt9B7o9Wve2NbE/Xxae5X/2A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pithekos-lib/-/pithekos-lib-0.6.0.tgz",
+      "integrity": "sha512-xqhSsPdpGOCirA1i2f3Z0W7M+M2TtqbUM+NilkfpmKy2URrKFGM8Ds6pEr6rirBjqvxZeSpHisAuJL/qmUhK9g==",
       "dependencies": {
         "@babel/cli": "^7.24.8",
         "@babel/core": "^7.24.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "dompurify": "^3.2.4",
         "eslint-config-react-app": "^7.0.1",
         "font-detect-rhl": "^1.1.7",
-        "pithekos-lib": "^0.5.0",
+        "pithekos-lib": "^0.5.11",
         "prop-types": "^15.8.1",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
@@ -14648,9 +14648,9 @@
       }
     },
     "node_modules/pithekos-lib": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/pithekos-lib/-/pithekos-lib-0.5.0.tgz",
-      "integrity": "sha512-tGbfNI487eE3rCRbC1c1wAm7IVYG26/O6bY5OMZAU8JUfoNgcSU9YJo718wBNGXEOer6BUEEz1ldpIAV0APz8g==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/pithekos-lib/-/pithekos-lib-0.5.11.tgz",
+      "integrity": "sha512-dsHGyMamn8qq6ZzC/xGK6kolYa2ltysQgnoJyynK0cFP3Ju0g/NIwp28Oq90PES/ecUDdnVmE5GIq3U1avmNog==",
       "dependencies": {
         "@babel/cli": "^7.24.8",
         "@babel/core": "^7.24.8",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dompurify": "^3.2.4",
     "eslint-config-react-app": "^7.0.1",
     "font-detect-rhl": "^1.1.7",
-    "pithekos-lib": "^0.5.11",
+    "pithekos-lib": "^0.5.24",
     "prop-types": "^15.8.1",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dompurify": "^3.2.4",
     "eslint-config-react-app": "^7.0.1",
     "font-detect-rhl": "^1.1.7",
-    "pithekos-lib": "^0.5.0",
+    "pithekos-lib": "^0.5.11",
     "prop-types": "^15.8.1",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dompurify": "^3.2.4",
     "eslint-config-react-app": "^7.0.1",
     "font-detect-rhl": "^1.1.7",
-    "pithekos-lib": "^0.5.24",
+    "pithekos-lib": "^0.6.0",
     "prop-types": "^15.8.1",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/src/components/BlendedFontSelection.jsx
+++ b/src/components/BlendedFontSelection.jsx
@@ -16,7 +16,7 @@ import FontFeaturesOther from "./FontFeaturesOther";
 import FontFeaturesFallback from "./FontFeaturesFallback";
 
 export default function BlendedFontSelection(blendedFontSelectionProps) {
-  const i18n = useContext(I18nContext);
+  const { i18nRef } = useContext(I18nContext);
   const {
     activeFontClass,
     setSelectedFontClass,
@@ -161,7 +161,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
         { display_name: 'Galatia SIL 2.1', id: 'Pankosmia-GalatiaSIL', name: 'Pankosmia-Galatia SIL', settings_id: '' },
       ]);
     }
-  },[i18n, webFontsGreek.length]);
+  },[webFontsGreek.length]);
   useEffect(() => {
     if (!webFontsMyanmar.length) {
       setWebFontsMyanmar([
@@ -169,7 +169,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
         { display_name: 'Padauk Book 5.100', id: 'Pankosmia-PadaukBook', name: 'Pankosmia-Padauk Book', settings_id: 'Padauk' },
       ]);
     }
-  },[i18n, webFontsMyanmar.length]);
+  },[webFontsMyanmar.length]);
   useEffect(() => {
     if (!webFontsArabicUrdu.length) {
       setWebFontsArabicUrdu([
@@ -180,7 +180,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
         { display_name: 'Noto Naskh Arabic 2.018', id: 'Pankosmia-NotoNaskhArabic', name: 'Pankosmia-Noto Naskh Arabic', settings_id: '' },
       ]);
     }
-  },[i18n, webFontsArabicUrdu.length]);
+  },[webFontsArabicUrdu.length]);
   useEffect(() => {
     if (!webFontsOther.length) {
       setWebFontsOther([
@@ -194,7 +194,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
         { display_name: 'Roboto Thin 2.137', id: 'Pankosmia-RobotoThin', name: 'Pankosmia-Roboto Thin', settings_id: '' },
       ]);
     }
-  },[i18n, webFontsOther.length]);
+  },[webFontsOther.length]);
   useEffect(() => {
     if (!webFontsFallback.length) {
       setWebFontsFallback([
@@ -205,7 +205,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
   },[webFontsFallback.length]);
 
   /** Add not-applicable options to script-specific arrays above. */
-  const otherFallbackFont = doI18n("pages:core-settings:other-fallback", i18n);
+  const otherFallbackFont = doI18n("pages:core-settings:other-fallback", i18nRef.current);
   useEffect(() => {
     if (otherFallbackFont !== 'pages:core-settings:other-fallback') {
       setWebFontsHebrew(previous => [...previous, { display_name: '- ' + otherFallbackFont + ' -', id: '', name: '', settings_id: '' },])
@@ -216,7 +216,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
   },[otherFallbackFont]);
 
   /** Add not-applicable options to the "Other" array above. */
-  const fallbackFont = doI18n("pages:core-settings:fallback", i18n);
+  const fallbackFont = doI18n("pages:core-settings:fallback", i18nRef.current);
   useEffect(() => {
     if (fallbackFont !== 'pages:core-settings:fallback') {
       setWebFontsOther(previous => [...previous, { display_name: '- ' + fallbackFont + ' -', id: '', name: '', settings_id: '' },])
@@ -775,13 +775,13 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
   return (
     <Grid2 container spacing={2}>
       <Grid2 size={12} sx={{ borderTop: 1, borderColor: 'purple' }}>
-        <h1>{doI18n("pages:core-settings:select_hebrewscriptfont", i18n)}</h1>
+        <h1>{doI18n("pages:core-settings:select_hebrewscriptfont", i18nRef.current)}</h1>
         <div item style={{maxWidth: 350, padding: "1.25em 0 0 0"}}>
             <Box sx={{minWidth: 350}}>
               <Stack direction="row">
                 <FormControl fullWidth style={{maxWidth: 325}} size="small">
                     <InputLabel id="select-hebrew-font-label" htmlFor="select-hebrew-font-id" sx={sx.inputLabel}>
-                      {doI18n("pages:core-settings:select_hebrewscriptfont", i18n)}
+                      {doI18n("pages:core-settings:select_hebrewscriptfont", i18nRef.current)}
                     </InputLabel>
                     <Select
                         variant="outlined"
@@ -791,7 +791,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
                             id: "select-hebrew-font-id",
                         }}
                         value={isActiveLoaded && hebrewClassSubstr}
-                        label={doI18n("pages:core-settings:select_hebrewscriptfont", i18n)}
+                        label={doI18n("pages:core-settings:select_hebrewscriptfont", i18nRef.current)}
                         onChange={handleChangeHebrew}
                         sx={sx.select}
                     >
@@ -830,13 +830,13 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
         </Box>
       </Grid2>
       <Grid2  size={12}>
-        <h1>{doI18n("pages:core-settings:select_greekscriptfont", i18n)}</h1>
+        <h1>{doI18n("pages:core-settings:select_greekscriptfont", i18nRef.current)}</h1>
         <div item style={{maxWidth: 350, padding: "1.25em 0 0 0"}}>
             <Box sx={{minWidth: 350}}>
               <Stack direction="row">
                   <FormControl fullWidth style={{maxWidth: 325}} size="small">
                       <InputLabel id="select-greek-font-label" htmlFor="select-greek-font-id" sx={sx.inputLabel}>
-                        {doI18n("pages:core-settings:select_greekscriptfont", i18n)}
+                        {doI18n("pages:core-settings:select_greekscriptfont", i18nRef.current)}
                       </InputLabel>
                       <Select
                           variant="outlined"
@@ -846,7 +846,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
                               id: "select-greek-font-id",
                           }}
                           value={isActiveLoaded && greekClassSubstr}
-                          label={doI18n("pages:core-settings:select_greekscriptfont", i18n)}
+                          label={doI18n("pages:core-settings:select_greekscriptfont", i18nRef.current)}
                           onChange={handleChangeGreek}
                           sx={sx.select}
                       >
@@ -886,13 +886,13 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
         </Box>
       </Grid2>
       <Grid2  size={12}>
-        <h1>{doI18n("pages:core-settings:select_myanmarscriptfont", i18n)}</h1>
+        <h1>{doI18n("pages:core-settings:select_myanmarscriptfont", i18nRef.current)}</h1>
         <div item style={{maxWidth: 350, padding: "1.25em 0 0 0"}}>
             <Box sx={{minWidth: 350}}>
               <Stack direction="row">
                 <FormControl fullWidth style={{maxWidth: 325}} size="small">
                     <InputLabel id="select-myanmar-font-label" htmlFor="select-myanmar-font-id" sx={sx.inputLabel}>
-                      {doI18n("pages:core-settings:select_myanmarscriptfont", i18n)}
+                      {doI18n("pages:core-settings:select_myanmarscriptfont", i18nRef.current)}
                     </InputLabel>
                     <Select
                         variant="outlined"
@@ -902,7 +902,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
                             id: "select-myanmar-font-id",
                         }}
                         value={isActiveLoaded && myanmarClassSubstr}
-                        label={doI18n("pages:core-settings:select_myanmarscriptfont", i18n)}
+                        label={doI18n("pages:core-settings:select_myanmarscriptfont", i18nRef.current)}
                         onChange={handleChangeMyanmar}
                         sx={sx.select}
                     >
@@ -941,13 +941,13 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
         </Box>
       </Grid2>
       <Grid2  size={12}>
-        <h1>{doI18n("pages:core-settings:select_arabicurduscriptfont", i18n)}</h1>
+        <h1>{doI18n("pages:core-settings:select_arabicurduscriptfont", i18nRef.current)}</h1>
         <div item style={{maxWidth: 350, padding: "1.25em 0 0 0"}}>
             <Box sx={{minWidth: 350}}>
               <Stack direction="row">
                 <FormControl fullWidth style={{maxWidth: 325}} size="small">
                     <InputLabel id="select-arabic-urdu-font-label" htmlFor="select-arabic-urdu-font-id" sx={sx.inputLabel}>
-                      {doI18n("pages:core-settings:select_arabicurduscriptfont", i18n)}
+                      {doI18n("pages:core-settings:select_arabicurduscriptfont", i18nRef.current)}
                     </InputLabel>
                     <Select
                         variant="outlined"
@@ -957,13 +957,13 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
                             id: "select-arabic-urdu-font-id",
                         }}
                         value={isActiveLoaded && arabicUrduClassSubstr}
-                        label={doI18n("pages:core-settings:select_arabicurduscriptfont", i18n)}
+                        label={doI18n("pages:core-settings:select_arabicurduscriptfont", i18nRef.current)}
                         onChange={handleChangeArabicUrdu}
                         sx={sx.select}
                     >
                       {WebFontsSelectableArabicUrdu}
                     </Select>
-                    <FormHelperText>{arabicUrduClassSubstr.includes('AwamiNastaliq') && doI18n("pages:core-settings:replaceawamiifnotfirefox", i18n)}</FormHelperText>
+                    <FormHelperText>{arabicUrduClassSubstr.includes('AwamiNastaliq') && doI18n("pages:core-settings:replaceawamiifnotfirefox", i18nRef.current)}</FormHelperText>
                 </FormControl>
                 {showArabicUrduFeatures && <FontFeaturesArabicUrdu {...fontFeaturesArabicUrduProps} />}
               </Stack>
@@ -997,14 +997,14 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
         </Box>
       </Grid2>
       <Grid2 size={12}>
-        <h1>{doI18n("pages:core-settings:select_otherscriptfont", i18n)} / {doI18n("pages:core-settings:select_fallbackscriptfont", i18n)}</h1>
+        <h1>{doI18n("pages:core-settings:select_otherscriptfont", i18nRef.current)} / {doI18n("pages:core-settings:select_fallbackscriptfont", i18nRef.current)}</h1>
         <Stack>
           <div item style={{maxWidth: 350, padding: "1.25em 0 0"}}>
               <Box sx={{minWidth: 350}}>
                 <Stack direction="row">
                   <FormControl fullWidth style={{maxWidth: 325}} size="small">
                       <InputLabel id="select-other-font-label" htmlFor="select-other-font-id" sx={sx.inputLabel}>
-                        {doI18n("pages:core-settings:select_otherscriptfont", i18n)}
+                        {doI18n("pages:core-settings:select_otherscriptfont", i18nRef.current)}
                       </InputLabel>
                       <Select
                           variant="outlined"
@@ -1014,7 +1014,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
                               id: "select-other-font-id",
                           }}
                           value={isActiveLoaded && otherClassSubstr}
-                          label={doI18n("pages:core-settings:select_otherscriptfont", i18n)}
+                          label={doI18n("pages:core-settings:select_otherscriptfont", i18nRef.current)}
                           onChange={handleChangeOther}
                           sx={sx.select}
                       >
@@ -1030,7 +1030,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
                 <Stack direction="row">
                   <FormControl fullWidth style={{maxWidth: 325}} size="small">
                       <InputLabel id="select-fallback-font-label" htmlFor="select-fallback-font-id" sx={sx.inputLabel}>
-                        {doI18n("pages:core-settings:select_fallbackscriptfont", i18n)}
+                        {doI18n("pages:core-settings:select_fallbackscriptfont", i18nRef.current)}
                       </InputLabel>
                       <Select
                           variant="outlined"
@@ -1040,7 +1040,7 @@ export default function BlendedFontSelection(blendedFontSelectionProps) {
                               id: "select-fallback-font-id",
                           }}
                           value={isActiveLoaded && fallbackClassSubstr}
-                          label={doI18n("pages:core-settings:select_fallbackscriptfont", i18n)}
+                          label={doI18n("pages:core-settings:select_fallbackscriptfont", i18nRef.current)}
                           onChange={handleChangeFallback}
                           sx={sx.select}
                       >

--- a/src/components/LanguageSelection.jsx
+++ b/src/components/LanguageSelection.jsx
@@ -8,7 +8,7 @@ import LanguageMenuItem from "./LanguageMenuItem";
 
 export default function LanguageSelection() {
 
-  const i18n = useContext(i18nContext);
+  const { i18nRef } = useContext(i18nContext);
   const [usedEndonyms, setUsedEndonyms] = useState([]);
   const [secondUsedEndonyms, setSecondUsedEndonyms] = useState([]);
   const [thirdUsedEndonyms, setThirdUsedEndonyms] = useState([]);
@@ -274,7 +274,10 @@ export default function LanguageSelection() {
 
   const postLanguageId = async (iD) => { 
     await postEmptyJson('/settings/languages/' + iD);
-    window.location.reload(false);
+    await getAndSetJson({
+      url: "/settings/languages",
+      setter: setSelectedLanguages
+    })
   };
 
   /** Build dropdown menus */
@@ -305,7 +308,7 @@ export default function LanguageSelection() {
               <Stack direction="row">
                 <FormControl size="small">
                     <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
-                      {doI18n("pages:core-settings:language", i18n)}
+                      {doI18n("pages:core-settings:language", i18nRef.current)}
                     </InputLabel>
                     <Select
                         variant="outlined"
@@ -315,7 +318,7 @@ export default function LanguageSelection() {
                             id: "select-language",
                         }}
                         value={firstSelectedLanguage}
-                        label={doI18n("pages:core-settings:language", i18n)}
+                        label={doI18n("pages:core-settings:language", i18nRef.current)}
                         onChange={handleFirstChangeLanguage}
                         sx={sx.select}
                     >
@@ -334,7 +337,7 @@ export default function LanguageSelection() {
                 <Stack direction="row">
                   <FormControl size="small">
                       <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
-                        {doI18n("pages:core-settings:language", i18n)}
+                        {doI18n("pages:core-settings:language", i18nRef.current)}
                       </InputLabel>
                       <Select
                           variant="outlined"
@@ -344,7 +347,7 @@ export default function LanguageSelection() {
                               id: "select-language",
                           }}
                           value={secondSelectedLanguage}
-                          label={doI18n("pages:core-settings:language", i18n)}
+                          label={doI18n("pages:core-settings:language", i18nRef.current)}
                           onChange={handleSecondChangeLanguage}
                           sx={sx.select}
                       >
@@ -364,7 +367,7 @@ export default function LanguageSelection() {
                 <Stack direction="row">
                   <FormControl size="small">
                       <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
-                        {doI18n("pages:core-settings:language", i18n)}
+                        {doI18n("pages:core-settings:language", i18nRef.current)}
                       </InputLabel>
                       <Select
                           variant="outlined"
@@ -374,7 +377,7 @@ export default function LanguageSelection() {
                               id: "select-language",
                           }}
                           value={thirdSelectedLanguage}
-                          label={doI18n("pages:core-settings:language", i18n)}
+                          label={doI18n("pages:core-settings:language", i18nRef.current)}
                           onChange={handleThirdChangeLanguage}
                           sx={sx.select}
                       >

--- a/src/components/LanguageSelection.jsx
+++ b/src/components/LanguageSelection.jsx
@@ -1,395 +1,129 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 
 import { Grid2, Box, InputLabel, FormControl, Select, MenuItem, Stack } from "@mui/material";
 import RemoveCircleIcon from '@mui/icons-material/RemoveCircle';
-import { i18nContext, doI18n, getAndSetJson, postEmptyJson} from "pithekos-lib";
+import { i18nContext, doI18n, postEmptyJson } from "pithekos-lib";
 import sx from "./Selection.styles";
 import LanguageMenuItem from "./LanguageMenuItem";
 
-export default function LanguageSelection() {
-
-  const { i18nRef } = useContext(i18nContext);
-  const [usedEndonyms, setUsedEndonyms] = useState([]);
-  const [secondUsedEndonyms, setSecondUsedEndonyms] = useState([]);
-  const [thirdUsedEndonyms, setThirdUsedEndonyms] = useState([]);
-  const [selectedLanguages, setSelectedLanguages] = useState('');
-  const [firstSelectedLanguage, setFirstSelectedLanguage] = useState('');
-  const [secondSelectedLanguage, setSecondSelectedLanguage] = useState('');
-  const [thirdSelectedLanguage, setThirdSelectedLanguage] = useState('');
-  const [fourthSelectedLanguage, setFourthSelectedLanguage] = useState('');
-  const [usedLanguages, setUsedLanguages] = useState([]);
-  useEffect(
-    () => {
-        getAndSetJson({
-            url: "/i18n/used-languages",
-            setter: setUsedLanguages
-        }).then()
-        getAndSetJson({
-          url: "/settings/languages",
-          setter: setSelectedLanguages
-        }).then()},
-    []
+const LanguageSelector = ({usedLanguages, languageChoices, setLanguageChoices, langN, selectedLanguage, doChange}) => {
+  const {i18nRef} = useContext(i18nContext);
+  return (
+        <div item style={{padding: "1.25em 0 0 0"}}>
+          <Box>
+            <Stack direction="row">
+              <FormControl size="small">
+                  <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
+                      {doI18n("pages:core-settings:language", i18nRef.current)}{" "}{langN + 1}
+                  </InputLabel>
+                  <Select
+                      variant="outlined"
+                      labelId="select-language-label"
+                      name="select-language"
+                      inputProps={{
+                          id: "select-language",
+                      }}
+                      value={selectedLanguage}
+                      label={doI18n("pages:core-settings:language", i18nRef.current)}
+                      onChange={ev => doChange(languageChoices, ev.target.value, langN, setLanguageChoices)}
+                      sx={sx.select}
+                  >
+                      {
+                          usedLanguages.filter(item => !languageChoices.slice(0, langN).includes(item.id)).map((language, n) => <MenuItem key={n} value={language.id} dense>
+                                  <LanguageMenuItem language={language}/>
+                              </MenuItem>
+                          )
+                      }
+                  </Select>
+              </FormControl>
+              {selectedLanguage !== 'en' && <RemoveCircleIcon style={{ color: "purple" }} onClick={ev => doChange(languageChoices, selectedLanguage, langN, setLanguageChoices, langN)}  />}
+            </Stack>
+          </Box>
+        </div>
   );
+}
 
-  useEffect(() => {
-    // ISO_639-1
-    const languageLookup = [
-      { id: 'ab', endonym: 'Аҧсуа; Apsua; აფსუა' },
-      { id: 'aa', endonym: 'Qafar af' },
-      { id: 'af', endonym: 'Afrikaans' },
-      { id: 'ak', endonym: 'Ákán' },
-      { id: 'sq', endonym: 'Shqip' },
-      { id: 'am', endonym: 'አማርኛ (Amarəñña)' },
-      { id: 'ar', endonym: 'اَلْعَرَبِيَّةُ (al-ʿarabiyyah)' },
-      { id: 'an', endonym: 'Aragonés' },
-      { id: 'hy', endonym: 'Հայերեն (Hayeren)' },
-      { id: 'as', endonym: 'অসমীয়া (Ôxômiya)' },
-      { id: 'av', endonym: 'Авар мацӏ; اوار ماض (Avar maz)' },
-      { id: 'ae', endonym: 'Upastawakaēna' },
-      { id: 'ay', endonym: 'Aymara' },
-      { id: 'az', endonym: 'Azərbaycan dili; آذربایجان دیلی; Азәрбајҹан дили' },
-      { id: 'bm', endonym: 'بَمَنَنكَن ;ߓߡߊߣߊ߲ߞߊ߲ (Bamanankan)' },
-      { id: 'ba', endonym: 'Башҡорт теле; Başqort tele' },
-      { id: 'eu', endonym: 'Euskara' },
-      { id: 'be', endonym: 'Беларуская мова (Belaruskaâ mova)' },
-      { id: 'bn', endonym: 'বাংলা (Bāŋlā)' },
-      { id: 'bi', endonym: 'Bislama' },
-      { id: 'bs', endonym: 'Босански (Bosanski)' },
-      { id: 'br', endonym: 'Brezhoneg' },
-      { id: 'bg', endonym: 'Български (Bulgarski)' },
-      { id: 'my', endonym: 'မြန်မာစာ (Mrãmācā)' },
-      { id: 'ca', endonym: 'Català; Valencià' },
-      { id: 'km', endonym: 'ខេមរភាសា; (Khémôrôphéasa)' },
-      { id: 'ch', endonym: 'Finu\' Chamoru' },
-      { id: 'ce', endonym: 'Нохчийн мотт; (Noxçiyn mott)' },
-      { id: 'ny', endonym: 'Chichewa; Chinyanja' },
-      { id: 'zh', endonym: '中文 (Zhōngwén) 汉语; 漢語 (Hànyǔ)' },
-      { id: 'cu', endonym: 'Славе́нскїй ѧ҆зы́къ' },
-      { id: 'cv', endonym: 'Чӑвашла (Çăvaşla)' },
-      { id: 'kw', endonym: 'Kernowek' },
-      { id: 'co', endonym: 'Corsu' },
-      { id: 'cr', endonym: 'ᓀᐦᐃᔭᐁᐧᐃᐧᐣ (Nehiyawewin)' },
-      { id: 'hr', endonym: 'Hrvatski' },
-      { id: 'cs', endonym: 'Čeština' },
-      { id: 'da', endonym: 'Dansk' },
-      { id: 'dv', endonym: 'ދިވެހި (Dhivehi)' },
-      { id: 'nl', endonym: 'Nederlands' },
-      { id: 'dz', endonym: 'རྫོང་ཁ་ (Dzongkha)' },
-      { id: 'en', endonym: 'English' },
-      { id: 'eo', endonym: 'Esperanto' },
-      { id: 'et', endonym: 'Eesti keel' },
-      { id: 'ee', endonym: 'Èʋegbe' },
-      { id: 'fo', endonym: 'Føroyskt' },
-      { id: 'fj', endonym: 'Na Vosa Vakaviti' },
-      { id: 'fi', endonym: 'Suomi' },
-      { id: 'fr', endonym: 'Français' },
-      { id: 'ff', endonym: '𞤊𞤵𞤤𞤬𞤵𞤤𞤣𞤫 ;ࢻُلْࢻُلْدٜ; Fulfulde 𞤆𞤵𞤤𞤢𞥄𞤪 ;ݒُلَارْ; Pulaar' },
-      { id: 'gd', endonym: 'Gàidhlig' },
-      { id: 'gl', endonym: 'Galego' },
-      { id: 'lg', endonym: 'Luganda' },
-      { id: 'ka', endonym: 'ქართული (Kharthuli)' },
-      { id: 'de', endonym: 'Deutsch' },
-      { id: 'el', endonym: 'Νέα Ελληνικά; (Néa Ellêniká)' },
-      { id: 'grc', endonym: 'Ἑλλάς'},
-      { id: 'gn', endonym: 'Avañe\'ẽ' },
-      { id: 'gu', endonym: 'ગુજરાતી (Gujarātī)' },
-      { id: 'ht', endonym: 'Kreyòl ayisyen' },
-      { id: 'ha', endonym: 'هَرْشٜن هَوْس (halshen Hausa)' },
-      { id: 'he', endonym: 'עברית‎ (Ivrit)' },
-      { id: 'hz', endonym: 'Otjiherero' },
-      { id: 'hi', endonym: 'हिन्दी (Hindī)' },
-      { id: 'ho', endonym: 'Hiri Motu' },
-      { id: 'hu', endonym: 'Magyar nyelv' },
-      { id: 'is', endonym: 'Íslenska' },
-      { id: 'io', endonym: 'Ido' },
-      { id: 'ig', endonym: 'ásụ̀sụ́ Ìgbò' },
-      { id: 'id', endonym: 'bahasa Indonesia' },
-      { id: 'ia', endonym: 'Interlingua' },
-      { id: 'ie', endonym: 'Interlingue; Occidental' },
-      { id: 'iu', endonym: 'ᐃᓄᒃᑎᑐᑦ (Inuktitut)' },
-      { id: 'ik', endonym: 'Iñupiaq' },
-      { id: 'ga', endonym: 'Gaeilge' },
-      { id: 'it', endonym: 'Italiano' },
-      { id: 'ja', endonym: '日本語 (Nihongo)' },
-      { id: 'jv', endonym: 'ꦧꦱꦗꦮ; basa Jawa' },
-      { id: 'kl', endonym: 'Kalaallisut' },
-      { id: 'kn', endonym: 'ಕನ್ನಡ (Kannađa)' },
-      { id: 'kr', endonym: 'كَنُرِيِه; Kànùrí' },
-      { id: 'ks', endonym: 'कॉशुर; كأشُر (Kosher)' },
-      { id: 'kk', endonym: 'Қазақша; Qazaqşa' },
-      { id: 'ki', endonym: 'Gĩgĩkũyũ' },
-      { id: 'rw', endonym: 'Ikinyarwanda' },
-      { id: 'kv', endonym: 'Коми кыв' },
-      { id: 'kg', endonym: 'Kikongo' },
-      { id: 'ko', endonym: '한국어 (Hangugeo) 조선말 (Chosŏnmal)' },
-      { id: 'kj', endonym: 'Oshikwanyama' },
-      { id: 'ku', endonym: 'کوردی; Kurdî' },
-      { id: 'ky', endonym: 'Кыргыз' },
-      { id: 'lo', endonym: 'ພາສາລາວ (phasa Lao)' },
-      { id: 'la', endonym: 'Latinum' },
-      { id: 'lv', endonym: 'Latviski' },
-      { id: 'li', endonym: 'Lèmburgs' },
-      { id: 'ln', endonym: 'Lingála' },
-      { id: 'lt', endonym: 'Lietuvių' },
-      { id: 'lu', endonym: 'Kiluba' },
-      { id: 'lb', endonym: 'Lëtzebuergesch' },
-      { id: 'mk', endonym: 'Македонски (Makedonski)' },
-      { id: 'mg', endonym: 'مَلَغَسِ; Malagasy' },
-      { id: 'ms', endonym: 'بهاس ملايو (bahasa Melayu)' },
-      { id: 'ml', endonym: 'മലയാളം (Malayāļã)' },
-      { id: 'mt', endonym: 'Malti' },
-      { id: 'gv', endonym: 'Gaelg; Gailck' },
-      { id: 'mi', endonym: 'reo Māori' },
-      { id: 'mr', endonym: 'मराठी (Marāṭhī)' },
-      { id: 'mh', endonym: 'kajin M̧ajel‌̧' },
-      { id: 'mn', endonym: 'ᠮᠣᠩᠭᠣᠯ ᠬᠡᠯᠡ; Монгол хэл (Mongol xel)' },
-      { id: 'na', endonym: 'dorerin Naoe' },
-      { id: 'nv', endonym: 'Diné bizaad; Naabeehó bizaad' },
-      { id: 'ng', endonym: 'Ndonga' },
-      { id: 'ne', endonym: 'नेपाली भाषा (Nepālī bhāśā)' },
-      { id: 'nd', endonym: 'isiNdebele; saseNyakatho; Mthwakazi Ndebele' },
-      { id: 'se', endonym: 'Davvisámegiella' },
-      { id: 'no', endonym: 'Norsk' },
-      { id: 'nb', endonym: 'Norsk Bokmål' },
-      { id: 'nn', endonym: 'Norsk Nynorsk' },
-      { id: 'oc', endonym: 'Occitan; Provençal' },
-      { id: 'oj', endonym: 'ᐊᓂᔑᓈᐯᒧᐎᓐ (Anishinaabemowin)' },
-      { id: 'or', endonym: 'ଓଡ଼ିଆ (Odia)' },
-      { id: 'om', endonym: 'afaan Oromoo' },
-      { id: 'os', endonym: 'дигорон Ӕвзаг (digoron Ævzag)' },
-      { id: 'pi', endonym: 'Pāli' },
-      { id: 'ps', endonym: 'پښتو (Pax̌tow)' },
-      { id: 'fa', endonym: 'فارسی (Fārsiy)' },
-      { id: 'pl', endonym: 'Polski' },
-      { id: 'pt', endonym: 'Português' },
-      { id: 'pa', endonym: 'ਪੰਜਾਬੀ; پنجابی (Pãjābī)' },
-      { id: 'qu', endonym: 'Runa simi; kichwa simi; Nuna shimi' },
-      { id: 'ro', endonym: 'Română; Ромынэ' },
-      { id: 'rm', endonym: 'Rumantsch; Rumàntsch; Romauntsch; Romontsch' },
-      { id: 'rn', endonym: 'Ikirundi' },
-      { id: 'ru', endonym: 'Русский язык (Russkiĭ âzyk)' },
-      { id: 'sm', endonym: 'gagana Sāmoa' },
-      { id: 'sg', endonym: 'yângâ tî Sängö' },
-      { id: 'sa', endonym: 'संस्कृतम् (Saṃskṛtam)' },
-      { id: 'sc', endonym: 'Sardu' },
-      { id: 'sr', endonym: 'Српски (Srpski)' },
-      { id: 'sn', endonym: 'chiShona' },
-      { id: 'ii', endonym: 'ꆈꌠꉙ (Nuosuhxop)' },
-      { id: 'sd', endonym: 'سنڌي; सिन्धी (Sindhī)' },
-      { id: 'si', endonym: 'සිංහල (Siṁhala)' },
-      { id: 'sk', endonym: 'Slovenčina' },
-      { id: 'sl', endonym: 'Slovenščina' },
-      { id: 'so', endonym: 'Soomaali; 𐒈𐒝𐒑𐒛𐒐𐒘; سٝومالِ' },
-      { id: 'nr', endonym: 'isiNdebele; sakwaNdzundza' },
-      { id: 'st', endonym: 'Sesotho' },
-      { id: 'es', endonym: 'Español; Castellano' },
-      { id: 'su', endonym: 'basa Sunda; ᮘᮞ ᮞᮥᮔ᮪ᮓ; بَاسَا سُوْندَا' },
-      { id: 'sw', endonym: 'Kiswahili; كِسوَحِيلِ' },
-      { id: 'ss', endonym: 'siSwati' },
-      { id: 'sv', endonym: 'Svenska' },
-      { id: 'tl', endonym: 'Wikang Tagalog' },
-      { id: 'ty', endonym: 'reo Tahiti' },
-      { id: 'tg', endonym: 'Тоҷикӣ (Tojikī)' },
-      { id: 'ta', endonym: 'தமிழ் (Tamiḻ)' },
-      { id: 'tt', endonym: 'Татар теле; Tatar tele; تاتار تئلئ‎' },
-      { id: 'te', endonym: 'తెలుగు (Telugu)' },
-      { id: 'th', endonym: 'ภาษาไทย (Phasa Thai)' },
-      { id: 'bo', endonym: 'བོད་སྐད་ (Bodskad); ལྷ་སའི་སྐད་ (Lhas\'iskad)' },
-      { id: 'ti', endonym: 'ትግርኛ (Təgrəñña)' },
-      { id: 'to', endonym: 'lea faka-Tonga' },
-      { id: 'ts', endonym: 'Xitsonga' },
-      { id: 'tn', endonym: 'Setswana' },
-      { id: 'tr', endonym: 'Türkçe' },
-      { id: 'tk', endonym: 'Türkmençe; Түркменче; تۆرکمنچه' },
-      { id: 'tw', endonym: 'Twi' },
-      { id: 'ug', endonym: 'ئۇيغۇر تىلى; Уйғур тили; Uyƣur tili' },
-      { id: 'uk', endonym: 'Українська (Ukraїnska)' },
-      { id: 'ur', endonym: 'اُردُو (Urduw)' },
-      { id: 'uz', endonym: 'Ózbekça; ўзбекча; ئوزبېچه' },
-      { id: 've', endonym: 'Tshivenḓa' },
-      { id: 'vi', endonym: 'tiếng Việt' },
-      { id: 'vo', endonym: 'Volapük' },
-      { id: 'wa', endonym: 'Walon' },
-      { id: 'cy', endonym: 'Cymraeg' },
-      { id: 'fy', endonym: 'Frysk' },
-      { id: 'wo', endonym: 'وࣷلࣷفْ' },
-      { id: 'xh', endonym: 'isiXhosa' },
-      { id: 'yi', endonym: 'ייִדיש (Yidiš)' },
-      { id: 'yo', endonym: 'èdè Yorùbá' },
-      { id: 'za', endonym: '話僮 (Vahcuengh)' },
-      { id: 'zu', endonym: 'isiZulu' },
-    ];
-    
-    setUsedEndonyms(languageLookup.filter(item => usedLanguages.includes(item.id)));
-  
-  },[usedLanguages]);
+const LangSelectors = ({languageChoices, setLanguageChoices, usedLanguages, doChange}) => {
 
-  useEffect( () => {
-    setSecondUsedEndonyms(usedEndonyms.filter(item => (item.id !== firstSelectedLanguage)));
-    setThirdUsedEndonyms(usedEndonyms.filter(item => ((item.id !== firstSelectedLanguage) && (item.id !== secondSelectedLanguage))));
-  },[firstSelectedLanguage, secondSelectedLanguage, usedEndonyms]);
+  let selectorSpecs = [];
+  let usedHereLanguages = new Set([]);
+  for (const [n, lang] of languageChoices.entries()) {
+      selectorSpecs.push(
+          {
+              n,
+              selectedLanguage: lang,
+              usedLanguages: usedLanguages
+          }
+      );
+      usedHereLanguages.add(lang);
+  }
+  return <div>
+      {selectorSpecs.map((s, n) => <LanguageSelector
+          key={n}
+          langN={n}
+          selectedLanguage={s.selectedLanguage}
+          usedLanguages={s.usedLanguages}
+          languageChoices={languageChoices}
+          setLanguageChoices={setLanguageChoices}
+          doChange={doChange}/>)
+      }
+  </div>
+}
 
-  useEffect(() => {
-    setFirstSelectedLanguage(selectedLanguages[0]);
-    setSecondSelectedLanguage(selectedLanguages[1]);
-    setThirdSelectedLanguage(selectedLanguages[2]);
-    setFourthSelectedLanguage(selectedLanguages[3]);
-  },[selectedLanguages]);
-  
-  const handleFirstChangeLanguage = (event) => {
-    const addEn = ((event.target.value !== 'en') && (secondSelectedLanguage !== 'en') && (thirdSelectedLanguage !== 'en') ? '/en' : '')
-    const fallbackLanguages = (secondSelectedLanguage !== undefined ? '/' + secondSelectedLanguage : '') + (thirdSelectedLanguage !== undefined ? '/' + thirdSelectedLanguage : '')
-    const postLanguage = event.target.value + fallbackLanguages.replace('/' + event.target.value, '') + addEn;
-    postLanguageId(postLanguage);
-  };
+const doChange = (allLanguages, choice, langN, setLanguageChoices, remove) => {
+  let newLanguages = [];
+  for (const [n, lang] of allLanguages.entries()) {
+      if (newLanguages.includes(lang)) {
+          continue;
+      }
+      if (n === langN) {
+          if (newLanguages.includes(choice)) {
+              continue;
+          }
+          if (n !== remove) {
+            newLanguages.push(choice);
+          }
+          if (choice ===  "en") {
+              // break; // No options after English
+              continue
+          }
+          continue;
+      }
+      if (lang === "en") {
+          newLanguages.push("en");
+          // break; // No options after English
+      }
+      if (newLanguages.includes(lang)) {
+          continue;
+      }
+      newLanguages.push(lang);
+  }
+  // if (newLanguages[newLanguages.length - 1] !== "en") { // Always have English last
+  if (!newLanguages.includes("en")) { // English must appear somewhere
+       newLanguages.push("en");
+  }
+  const languageString = newLanguages.join('/');
+  postEmptyJson(`/settings/languages/${languageString}`).then();
+  setLanguageChoices(newLanguages);
+}
 
-  const handleSecondChangeLanguage = (event) => {
-    const addEn = ((firstSelectedLanguage !== 'en') && (event.target.value !== 'en') && (thirdSelectedLanguage !== 'en') ? '/en' : '')
-    const fallbackLanguages = (thirdSelectedLanguage !== undefined ? '/' + thirdSelectedLanguage : '')
-    const postLanguage = firstSelectedLanguage + '/' + event.target.value + fallbackLanguages.replace('/' + event.target.value, '') + addEn;
-    postLanguageId(postLanguage);
-  };
-
-  const handleThirdChangeLanguage = (event) => {
-    const addEn = ((firstSelectedLanguage !== 'en') && (secondSelectedLanguage !== 'en') && (event.target.value !== 'en') ? '/en' : '')
-    const second = (secondSelectedLanguage !== undefined ? '/' + secondSelectedLanguage : '')
-    const postLanguage = firstSelectedLanguage + second + '/' + event.target.value + addEn;
-    postLanguageId(postLanguage);
-  };
-
-  const handleRemoveFirstLanguage = (event) => {
-    const postLanguage = secondSelectedLanguage + (thirdSelectedLanguage !== undefined ? '/' + thirdSelectedLanguage : '') + (fourthSelectedLanguage !== undefined ? '/' + fourthSelectedLanguage : '')
-    postLanguageId(postLanguage);
-  };
-
-  const handleRemoveSecondLanguage = (event) => {
-    const postLanguage = firstSelectedLanguage + (thirdSelectedLanguage !== undefined ? '/' + thirdSelectedLanguage : '') + (fourthSelectedLanguage !== undefined ? '/' + fourthSelectedLanguage : '')
-    postLanguageId(postLanguage);
-  };
-
-  const handleRemoveThirdLanguage = (event) => {
-    const postLanguage = firstSelectedLanguage + '/' + secondSelectedLanguage + (fourthSelectedLanguage !== undefined ? '/' + fourthSelectedLanguage : '')
-    postLanguageId(postLanguage);
-  };
-
-  const postLanguageId = async (iD) => { 
-    await postEmptyJson('/settings/languages/' + iD);
-    await getAndSetJson({
-      url: "/settings/languages",
-      setter: setSelectedLanguages
-    })
-  };
-
-  /** Build dropdown menus */
-  const UsedEndonyms =
-    usedEndonyms.map((language, index) => (
-        <MenuItem key={index} value={language.id} dense>
-            <LanguageMenuItem language={language}/>
-        </MenuItem>
-  ));
-  const SecondUsedEndonyms =
-  secondUsedEndonyms.map((language, index) => (
-      <MenuItem key={index} value={language.id} dense>
-          <LanguageMenuItem language={language}/>
-      </MenuItem>
-  ));
-  const ThirdUsedEndonyms =
-  thirdUsedEndonyms.map((language, index) => (
-      <MenuItem key={index} value={language.id} dense>
-          <LanguageMenuItem language={language}/>
-      </MenuItem>
-  ));
+export default function LanguageSelection(languageSelectionProps) {
+  const {
+    languageChoices,
+    setLanguageChoices,
+    usedLanguages
+  } = languageSelectionProps;
 
   return (
     <Grid2 container spacing={2}>
-      <Grid2 size={12} sx={{ borderTop: 1, borderColor: 'purple' }}>
-        <div item style={{padding: "1.25em 0 0 0"}}>
-            <Box>
-              <Stack direction="row">
-                <FormControl size="small">
-                    <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
-                      {doI18n("pages:core-settings:language", i18nRef.current)}
-                    </InputLabel>
-                    <Select
-                        variant="outlined"
-                        labelId="select-language-label"
-                        name="select-language"
-                        inputProps={{
-                            id: "select-language",
-                        }}
-                        value={firstSelectedLanguage}
-                        label={doI18n("pages:core-settings:language", i18nRef.current)}
-                        onChange={handleFirstChangeLanguage}
-                        sx={sx.select}
-                    >
-                      {UsedEndonyms}
-                    </Select>
-                </FormControl>
-                {firstSelectedLanguage !== 'en' && <RemoveCircleIcon style={{ color: "purple" }} onClick={handleRemoveFirstLanguage}  />}
-              </Stack>
-            </Box>
-        </div>
+      <Grid2 size={12}>
+        <LangSelectors
+            languageChoices={languageChoices}
+            setLanguageChoices={setLanguageChoices}
+            usedLanguages={usedLanguages}
+            doChange={doChange}
+        />
       </Grid2>
-      {secondSelectedLanguage !== undefined &&
-        <Grid2 size={12} sx={{ borderTop: 1, borderColor: 'purple' }}>
-          <div item style={{padding: "1.25em 0 0 0"}}>
-              <Box>
-                <Stack direction="row">
-                  <FormControl size="small">
-                      <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
-                        {doI18n("pages:core-settings:language", i18nRef.current)}
-                      </InputLabel>
-                      <Select
-                          variant="outlined"
-                          labelId="select-language-label"
-                          name="select-language"
-                          inputProps={{
-                              id: "select-language",
-                          }}
-                          value={secondSelectedLanguage}
-                          label={doI18n("pages:core-settings:language", i18nRef.current)}
-                          onChange={handleSecondChangeLanguage}
-                          sx={sx.select}
-                      >
-                        {SecondUsedEndonyms}
-                      </Select>
-                  </FormControl>
-                  {secondSelectedLanguage !== 'en' && <RemoveCircleIcon style={{ color: "purple" }} onClick={handleRemoveSecondLanguage}  />}
-                </Stack>
-              </Box>
-          </div>
-        </Grid2>
-      }
-      {thirdSelectedLanguage !== undefined &&
-        <Grid2 size={12} sx={{ borderTop: 1, borderColor: 'purple' }}>
-          <div item style={{padding: "1.25em 0 0 0"}}>
-              <Box>
-                <Stack direction="row">
-                  <FormControl size="small">
-                      <InputLabel id="select-language-label" htmlFor="select-language" sx={sx.inputLabel}>
-                        {doI18n("pages:core-settings:language", i18nRef.current)}
-                      </InputLabel>
-                      <Select
-                          variant="outlined"
-                          labelId="select-language-label"
-                          name="select-language"
-                          inputProps={{
-                              id: "select-language",
-                          }}
-                          value={thirdSelectedLanguage}
-                          label={doI18n("pages:core-settings:language", i18nRef.current)}
-                          onChange={handleThirdChangeLanguage}
-                          sx={sx.select}
-                      >
-                        {ThirdUsedEndonyms}
-                      </Select>
-                  </FormControl>
-                  {thirdSelectedLanguage !== 'en' && <RemoveCircleIcon style={{ color: "purple" }} onClick={handleRemoveThirdLanguage} />}
-                </Stack>
-              </Box>
-          </div>
-        </Grid2>
-      }
     </Grid2>
   );
 }

--- a/src/components/LanguageSelection.jsx
+++ b/src/components/LanguageSelection.jsx
@@ -36,7 +36,9 @@ const LanguageSelector = ({usedLanguages, languageChoices, setLanguageChoices, l
                       }
                   </Select>
               </FormControl>
-              {selectedLanguage !== 'en' && <RemoveCircleIcon style={{ color: "purple" }} onClick={ev => doChange(languageChoices, selectedLanguage, langN, setLanguageChoices, langN)}  />}
+              <div style={{margin: '8px auto auto 4px'}}>
+                {selectedLanguage !== 'en' && <RemoveCircleIcon style={{ color: "purple" }} onClick={ev => doChange(languageChoices, selectedLanguage, langN, setLanguageChoices, langN)}  />}
+              </div>
             </Stack>
           </Box>
         </div>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,7 +1,7 @@
-import { useContext, useState } from "react"
+import { useContext, useState, useEffect } from "react"
 import PropTypes from 'prop-types';
 import { Tabs, Tab, Box, Grid2, Switch } from "@mui/material";
-import { debugContext, i18nContext, doI18n, getJson } from "pithekos-lib";
+import {debugContext, i18nContext, doI18n, getJson, getAndSetJson, postEmptyJson} from "pithekos-lib";
 import BlendedFontsPage from "./BlendedFontsPage";
 import LanguageSelection from "./LanguageSelection";
 
@@ -36,8 +36,232 @@ const a11yProps = (index) => {
 
 export default function Settings() {
   const [value, setValue] = useState(0);
-  const {debugRef} = useContext(debugContext);
+  const { debugRef } = useContext(debugContext);
   const { i18nRef } = useContext(i18nContext);
+
+  const [languageChoices, setLanguageChoices] = useState(['en']);
+  const [usedLanguages, setUsedLanguages] = useState(['en']);
+  const [usedEndonyms, setUsedEndonyms] = useState([]);
+
+  useEffect(() =>
+      getAndSetJson({
+          url: "/settings/languages",
+          setter: setLanguageChoices
+      }).then(),
+    []
+  );
+
+  useEffect(() =>
+      getAndSetJson({
+          url: "/i18n/used-languages",
+          setter: setUsedLanguages
+      }).then(),
+    []
+  );
+  
+  useEffect(() => {
+    // ISO_639-1 plus grc
+    const languageLookup = [
+      { id: 'ab', endonym: 'Аҧсуа; Apsua; აფსუა' },
+      { id: 'aa', endonym: 'Qafar af' },
+      { id: 'af', endonym: 'Afrikaans' },
+      { id: 'ak', endonym: 'Ákán' },
+      { id: 'sq', endonym: 'Shqip' },
+      { id: 'am', endonym: 'አማርኛ (Amarəñña)' },
+      { id: 'ar', endonym: 'اَلْعَرَبِيَّةُ (al-ʿarabiyyah)' },
+      { id: 'an', endonym: 'Aragonés' },
+      { id: 'hy', endonym: 'Հայերեն (Hayeren)' },
+      { id: 'as', endonym: 'অসমীয়া (Ôxômiya)' },
+      { id: 'av', endonym: 'Авар мацӏ; اوار ماض (Avar maz)' },
+      { id: 'ae', endonym: 'Upastawakaēna' },
+      { id: 'ay', endonym: 'Aymara' },
+      { id: 'az', endonym: 'Azərbaycan dili; آذربایجان دیلی; Азәрбајҹан дили' },
+      { id: 'bm', endonym: 'بَمَنَنكَن ;ߓߡߊߣߊ߲ߞߊ߲ (Bamanankan)' },
+      { id: 'ba', endonym: 'Башҡорт теле; Başqort tele' },
+      { id: 'eu', endonym: 'Euskara' },
+      { id: 'be', endonym: 'Беларуская мова (Belaruskaâ mova)' },
+      { id: 'bn', endonym: 'বাংলা (Bāŋlā)' },
+      { id: 'bi', endonym: 'Bislama' },
+      { id: 'bs', endonym: 'Босански (Bosanski)' },
+      { id: 'br', endonym: 'Brezhoneg' },
+      { id: 'bg', endonym: 'Български (Bulgarski)' },
+      { id: 'my', endonym: 'မြန်မာစာ (Mrãmācā)' },
+      { id: 'ca', endonym: 'Català; Valencià' },
+      { id: 'km', endonym: 'ខេមរភាសា; (Khémôrôphéasa)' },
+      { id: 'ch', endonym: 'Finu\' Chamoru' },
+      { id: 'ce', endonym: 'Нохчийн мотт; (Noxçiyn mott)' },
+      { id: 'ny', endonym: 'Chichewa; Chinyanja' },
+      { id: 'zh', endonym: '中文 (Zhōngwén) 汉语; 漢語 (Hànyǔ)' },
+      { id: 'cu', endonym: 'Славе́нскїй ѧ҆зы́къ' },
+      { id: 'cv', endonym: 'Чӑвашла (Çăvaşla)' },
+      { id: 'kw', endonym: 'Kernowek' },
+      { id: 'co', endonym: 'Corsu' },
+      { id: 'cr', endonym: 'ᓀᐦᐃᔭᐁᐧᐃᐧᐣ (Nehiyawewin)' },
+      { id: 'hr', endonym: 'Hrvatski' },
+      { id: 'cs', endonym: 'Čeština' },
+      { id: 'da', endonym: 'Dansk' },
+      { id: 'dv', endonym: 'ދިވެހި (Dhivehi)' },
+      { id: 'nl', endonym: 'Nederlands' },
+      { id: 'dz', endonym: 'རྫོང་ཁ་ (Dzongkha)' },
+      { id: 'en', endonym: 'English' },
+      { id: 'eo', endonym: 'Esperanto' },
+      { id: 'et', endonym: 'Eesti keel' },
+      { id: 'ee', endonym: 'Èʋegbe' },
+      { id: 'fo', endonym: 'Føroyskt' },
+      { id: 'fj', endonym: 'Na Vosa Vakaviti' },
+      { id: 'fi', endonym: 'Suomi' },
+      { id: 'fr', endonym: 'Français' },
+      { id: 'ff', endonym: '𞤊𞤵𞤤𞤬𞤵𞤤𞤣𞤫 ;ࢻُلْࢻُلْدٜ; Fulfulde 𞤆𞤵𞤤𞤢𞥄𞤪 ;ݒُلَارْ; Pulaar' },
+      { id: 'gd', endonym: 'Gàidhlig' },
+      { id: 'gl', endonym: 'Galego' },
+      { id: 'lg', endonym: 'Luganda' },
+      { id: 'ka', endonym: 'ქართული (Kharthuli)' },
+      { id: 'de', endonym: 'Deutsch' },
+      { id: 'el', endonym: 'Νέα Ελληνικά; (Néa Ellêniká)' },
+      { id: 'grc', endonym: 'Ἑλλάς'},
+      { id: 'gn', endonym: 'Avañe\'ẽ' },
+      { id: 'gu', endonym: 'ગુજરાતી (Gujarātī)' },
+      { id: 'ht', endonym: 'Kreyòl ayisyen' },
+      { id: 'ha', endonym: 'هَرْشٜن هَوْس (halshen Hausa)' },
+      { id: 'he', endonym: 'עברית‎ (Ivrit)' },
+      { id: 'hz', endonym: 'Otjiherero' },
+      { id: 'hi', endonym: 'हिन्दी (Hindī)' },
+      { id: 'ho', endonym: 'Hiri Motu' },
+      { id: 'hu', endonym: 'Magyar nyelv' },
+      { id: 'is', endonym: 'Íslenska' },
+      { id: 'io', endonym: 'Ido' },
+      { id: 'ig', endonym: 'ásụ̀sụ́ Ìgbò' },
+      { id: 'id', endonym: 'bahasa Indonesia' },
+      { id: 'ia', endonym: 'Interlingua' },
+      { id: 'ie', endonym: 'Interlingue; Occidental' },
+      { id: 'iu', endonym: 'ᐃᓄᒃᑎᑐᑦ (Inuktitut)' },
+      { id: 'ik', endonym: 'Iñupiaq' },
+      { id: 'ga', endonym: 'Gaeilge' },
+      { id: 'it', endonym: 'Italiano' },
+      { id: 'ja', endonym: '日本語 (Nihongo)' },
+      { id: 'jv', endonym: 'ꦧꦱꦗꦮ; basa Jawa' },
+      { id: 'kl', endonym: 'Kalaallisut' },
+      { id: 'kn', endonym: 'ಕನ್ನಡ (Kannađa)' },
+      { id: 'kr', endonym: 'كَنُرِيِه; Kànùrí' },
+      { id: 'ks', endonym: 'कॉशुर; كأشُر (Kosher)' },
+      { id: 'kk', endonym: 'Қазақша; Qazaqşa' },
+      { id: 'ki', endonym: 'Gĩgĩkũyũ' },
+      { id: 'rw', endonym: 'Ikinyarwanda' },
+      { id: 'kv', endonym: 'Коми кыв' },
+      { id: 'kg', endonym: 'Kikongo' },
+      { id: 'ko', endonym: '한국어 (Hangugeo) 조선말 (Chosŏnmal)' },
+      { id: 'kj', endonym: 'Oshikwanyama' },
+      { id: 'ku', endonym: 'کوردی; Kurdî' },
+      { id: 'ky', endonym: 'Кыргыз' },
+      { id: 'lo', endonym: 'ພາສາລາວ (phasa Lao)' },
+      { id: 'la', endonym: 'Latinum' },
+      { id: 'lv', endonym: 'Latviski' },
+      { id: 'li', endonym: 'Lèmburgs' },
+      { id: 'ln', endonym: 'Lingála' },
+      { id: 'lt', endonym: 'Lietuvių' },
+      { id: 'lu', endonym: 'Kiluba' },
+      { id: 'lb', endonym: 'Lëtzebuergesch' },
+      { id: 'mk', endonym: 'Македонски (Makedonski)' },
+      { id: 'mg', endonym: 'مَلَغَسِ; Malagasy' },
+      { id: 'ms', endonym: 'بهاس ملايو (bahasa Melayu)' },
+      { id: 'ml', endonym: 'മലയാളം (Malayāļã)' },
+      { id: 'mt', endonym: 'Malti' },
+      { id: 'gv', endonym: 'Gaelg; Gailck' },
+      { id: 'mi', endonym: 'reo Māori' },
+      { id: 'mr', endonym: 'मराठी (Marāṭhī)' },
+      { id: 'mh', endonym: 'kajin M̧ajel‌̧' },
+      { id: 'mn', endonym: 'ᠮᠣᠩᠭᠣᠯ ᠬᠡᠯᠡ; Монгол хэл (Mongol xel)' },
+      { id: 'na', endonym: 'dorerin Naoe' },
+      { id: 'nv', endonym: 'Diné bizaad; Naabeehó bizaad' },
+      { id: 'ng', endonym: 'Ndonga' },
+      { id: 'ne', endonym: 'नेपाली भाषा (Nepālī bhāśā)' },
+      { id: 'nd', endonym: 'isiNdebele; saseNyakatho; Mthwakazi Ndebele' },
+      { id: 'se', endonym: 'Davvisámegiella' },
+      { id: 'no', endonym: 'Norsk' },
+      { id: 'nb', endonym: 'Norsk Bokmål' },
+      { id: 'nn', endonym: 'Norsk Nynorsk' },
+      { id: 'oc', endonym: 'Occitan; Provençal' },
+      { id: 'oj', endonym: 'ᐊᓂᔑᓈᐯᒧᐎᓐ (Anishinaabemowin)' },
+      { id: 'or', endonym: 'ଓଡ଼ିଆ (Odia)' },
+      { id: 'om', endonym: 'afaan Oromoo' },
+      { id: 'os', endonym: 'дигорон Ӕвзаг (digoron Ævzag)' },
+      { id: 'pi', endonym: 'Pāli' },
+      { id: 'ps', endonym: 'پښتو (Pax̌tow)' },
+      { id: 'fa', endonym: 'فارسی (Fārsiy)' },
+      { id: 'pl', endonym: 'Polski' },
+      { id: 'pt', endonym: 'Português' },
+      { id: 'pa', endonym: 'ਪੰਜਾਬੀ; پنجابی (Pãjābī)' },
+      { id: 'qu', endonym: 'Runa simi; kichwa simi; Nuna shimi' },
+      { id: 'ro', endonym: 'Română; Ромынэ' },
+      { id: 'rm', endonym: 'Rumantsch; Rumàntsch; Romauntsch; Romontsch' },
+      { id: 'rn', endonym: 'Ikirundi' },
+      { id: 'ru', endonym: 'Русский язык (Russkiĭ âzyk)' },
+      { id: 'sm', endonym: 'gagana Sāmoa' },
+      { id: 'sg', endonym: 'yângâ tî Sängö' },
+      { id: 'sa', endonym: 'संस्कृतम् (Saṃskṛtam)' },
+      { id: 'sc', endonym: 'Sardu' },
+      { id: 'sr', endonym: 'Српски (Srpski)' },
+      { id: 'sn', endonym: 'chiShona' },
+      { id: 'ii', endonym: 'ꆈꌠꉙ (Nuosuhxop)' },
+      { id: 'sd', endonym: 'سنڌي; सिन्धी (Sindhī)' },
+      { id: 'si', endonym: 'සිංහල (Siṁhala)' },
+      { id: 'sk', endonym: 'Slovenčina' },
+      { id: 'sl', endonym: 'Slovenščina' },
+      { id: 'so', endonym: 'Soomaali; 𐒈𐒝𐒑𐒛𐒐𐒘; سٝومالِ' },
+      { id: 'nr', endonym: 'isiNdebele; sakwaNdzundza' },
+      { id: 'st', endonym: 'Sesotho' },
+      { id: 'es', endonym: 'Español; Castellano' },
+      { id: 'su', endonym: 'basa Sunda; ᮘᮞ ᮞᮥᮔ᮪ᮓ; بَاسَا سُوْندَا' },
+      { id: 'sw', endonym: 'Kiswahili; كِسوَحِيلِ' },
+      { id: 'ss', endonym: 'siSwati' },
+      { id: 'sv', endonym: 'Svenska' },
+      { id: 'tl', endonym: 'Wikang Tagalog' },
+      { id: 'ty', endonym: 'reo Tahiti' },
+      { id: 'tg', endonym: 'Тоҷикӣ (Tojikī)' },
+      { id: 'ta', endonym: 'தமிழ் (Tamiḻ)' },
+      { id: 'tt', endonym: 'Татар теле; Tatar tele; تاتار تئلئ‎' },
+      { id: 'te', endonym: 'తెలుగు (Telugu)' },
+      { id: 'th', endonym: 'ภาษาไทย (Phasa Thai)' },
+      { id: 'bo', endonym: 'བོད་སྐད་ (Bodskad); ལྷ་སའི་སྐད་ (Lhas\'iskad)' },
+      { id: 'ti', endonym: 'ትግርኛ (Təgrəñña)' },
+      { id: 'to', endonym: 'lea faka-Tonga' },
+      { id: 'ts', endonym: 'Xitsonga' },
+      { id: 'tn', endonym: 'Setswana' },
+      { id: 'tr', endonym: 'Türkçe' },
+      { id: 'tk', endonym: 'Türkmençe; Түркменче; تۆرکمنچه' },
+      { id: 'tw', endonym: 'Twi' },
+      { id: 'ug', endonym: 'ئۇيغۇر تىلى; Уйғур тили; Uyƣur tili' },
+      { id: 'uk', endonym: 'Українська (Ukraїnska)' },
+      { id: 'ur', endonym: 'اُردُو (Urduw)' },
+      { id: 'uz', endonym: 'Ózbekça; ўзбекча; ئوزبېچه' },
+      { id: 've', endonym: 'Tshivenḓa' },
+      { id: 'vi', endonym: 'tiếng Việt' },
+      { id: 'vo', endonym: 'Volapük' },
+      { id: 'wa', endonym: 'Walon' },
+      { id: 'cy', endonym: 'Cymraeg' },
+      { id: 'fy', endonym: 'Frysk' },
+      { id: 'wo', endonym: 'وࣷلࣷفْ' },
+      { id: 'xh', endonym: 'isiXhosa' },
+      { id: 'yi', endonym: 'ייִדיש (Yidiš)' },
+      { id: 'yo', endonym: 'èdè Yorùbá' },
+      { id: 'za', endonym: '話僮 (Vahcuengh)' },
+      { id: 'zu', endonym: 'isiZulu' },
+    ];
+    
+    setUsedEndonyms(languageLookup.filter(item => usedLanguages.includes(item.id)));
+  
+  },[usedLanguages]);
+
+  console.log(languageChoices);
+  console.log(languageChoices.some(item => (item === 'en')));
+
+  useEffect(() => {
+    if (!languageChoices.some(item => (item === 'en'))) {
+      const languageString = languageChoices.join('/') + '/en';
+      postEmptyJson(`/settings/languages/${languageString}`).then();
+      setLanguageChoices(previous => [...previous, 'en',])
+    }
+  },[languageChoices])
 
   const handleChange = (event, newValue) => {
     setValue(newValue);
@@ -59,7 +283,11 @@ export default function Settings() {
         </Tabs>
       </Box>
       <CustomTabPanel value={value} index={0}>
-        <LanguageSelection />
+        <LanguageSelection
+          languageChoices={languageChoices}
+          setLanguageChoices={setLanguageChoices}
+          usedLanguages={usedEndonyms}
+        />
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
         <BlendedFontsPage />

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -252,9 +252,6 @@ export default function Settings() {
   
   },[usedLanguages]);
 
-  console.log(languageChoices);
-  console.log(languageChoices.some(item => (item === 'en')));
-
   useEffect(() => {
     if (!languageChoices.some(item => (item === 'en'))) {
       const languageString = languageChoices.join('/') + '/en';

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -37,7 +37,7 @@ const a11yProps = (index) => {
 export default function Settings() {
   const [value, setValue] = useState(0);
   const {debugRef} = useContext(debugContext);
-  const i18n = useContext(i18nContext);
+  const { i18nRef } = useContext(i18nContext);
 
   const handleChange = (event, newValue) => {
     setValue(newValue);
@@ -53,9 +53,9 @@ export default function Settings() {
           indicatorColor="secondary"        
           aria-label="basic tabs example"
         >
-          <Tab label={doI18n("pages:core-settings:language", i18n)} {...a11yProps(0)} />
-          <Tab label={doI18n("pages:core-settings:fonts", i18n)} {...a11yProps(1)} />
-          <Tab label={doI18n("pages:core-settings:debug_prompt", i18n)} {...a11yProps(2)} />
+          <Tab label={doI18n("pages:core-settings:language", i18nRef.current)} {...a11yProps(0)} />
+          <Tab label={doI18n("pages:core-settings:fonts", i18nRef.current)} {...a11yProps(1)} />
+          <Tab label={doI18n("pages:core-settings:debug_prompt", i18nRef.current)} {...a11yProps(2)} />
         </Tabs>
       </Box>
       <CustomTabPanel value={value} index={0}>
@@ -67,7 +67,7 @@ export default function Settings() {
       <CustomTabPanel value={value} index={2}>
       <Grid2 container>
         <Grid2 item size={1}>
-          <b>{doI18n("pages:core-settings:debug_prompt", i18n)}</b>
+          <b>{doI18n("pages:core-settings:debug_prompt", i18nRef.current)}</b>
         </Grid2>
           <Grid2 item size={11}>
             <Switch


### PR DESCRIPTION
### This PR:
- Merges recursive selection from [mvh/i18nMenusAgain](https://github.com/pankosmia/core-client-settings/tree/mvh/i18nMenusAgain) with:
  - endonyms
  - filtered options without previously selected languages available for re-selection as they aren't valid choices.
  - remove(*) option except for 'en'.
  - handling of a case where a user manually removes "en" from their user_settings.json
  - prior design, except that the purple line previously between dropdown rows is now removed.
  
(*) While there is another way to work out the same effect, this may be more straightforward for users that don't figure that out.