### PR TITLE
Change to Graphite detection.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/clients/main/favicon.ico" />
-    <link rel="stylesheet" href="/webfonts/_webfonts.css">
+    <link rel="stylesheet" href="/webfonts/_webfonts.css" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Pankosmia Editor" />

--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -87,14 +87,14 @@
       "grc": "Ἀραϐικὰ γράμματα"
     },
     "replace_awami": {
-      "en": "Noto Nastaliq Urdu if your browser is not Firefox",
-      "fr": "Noto Nastaliq Urdu si votre navigateur n'est pas Firefox",
-      "id": "Noto Nastaliq Urdu jika peramban web anda bukan Firefox"
+      "en": "Noto Nastaliq Urdu if not rendered on Graphite.",
+      "fr": "Noto Nastaliq Urdu si non rendu sur Graphite.",
+      "id": "Noto Nastaliq Urdu jika tidak ditampilkan atas Graphite."
     },
     "replace_noto": {
-      "en": "Replaced with Awami Nastaliq in Firefox",
-      "fr": "Remplacé par Awami Nastaliq dans Firefox",
-      "id": "Diganti dengan Awami Nastaliq di Firefox"
+      "en": "Replaced with Awami Nastaliq when Graphite is available.",
+      "fr": "Remplacé par Awami Nastaliq quand le Fraphite est disponible.",
+      "id": "Diganti dengan Awami Nastaliq ketika Graphite tersedia."
     },
     "current_settings": {
       "en": "Current Settings",
@@ -107,14 +107,24 @@
       "id": "Pengaturan Pabrik"
     },
     "best_with": {
-      "en": "Best viewed with Firefox.",
-      "fr": "Mieux vu avec Firefox.",
-      "id": "Terbaik dengan Firefox."
+      "en": "Best viewed with Graphite.",
+      "fr": "Mieux vu avec Graphite.",
+      "id": "Terbaik dengan Graphite."
     },
-    "if_not_firefox": {
-      "en": "Noto Nastaliq if not Firefox",
-      "fr": "Noto Nastaliq sinon Firefox",
-      "id": "Noto Nastaliq jika bukan Firefox"
+    "padauk_tip": {
+      "en": "Additional features available under Graphite.",
+      "fr": "Fonctionnalités supplémentaires disponibles sous Graphite.",
+      "id": "Fitur tambahan tersedia di bawah Graphite."
+    },
+    "graphite_support": {
+      "en": "Firefox and Electronite support Graphite.",
+      "fr": "Firefox et Electronite prennent en charge Graphite.",
+      "id": "Firefox dan Electronite mendukung Graphite."
+    },
+    "graphite_is_off": {
+      "en": "Set gfx.font_rendering.graphite.enabled to true in about:config to enable Graphite in Firefox.",
+      "id": "Atur gfx.font_rendering.graphite.enabled menjadi true di about:config untuk mengaktifkan Graphite di Firefox.",
+      "fr": "Définissez gfx.font_rendering.graphite.enabled sur true dans about:config pour activer Graphite dans Firefox."
     }
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/clients/main/favicon.ico" />
-    <link rel="stylesheet" href="/webfonts/_webfonts.css">
+    <link rel="stylesheet" href="/webfonts/_webfonts.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/components/BlendedFontArabicUrduSelection.jsx
+++ b/src/components/BlendedFontArabicUrduSelection.jsx
@@ -16,7 +16,8 @@ import FontFeaturesArabicUrdu from "./FontFeaturesArabicUrdu";
 export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSelectionProps) {
   const { i18nRef } = useContext(I18nContext);
   const {
-    isGraphiteAssumed,
+    isGraphite,
+    isFirefox,
     selectedArabicUrduFontClassSubstr,
     setSelectedArabicUrduFontClassSubstr,
     arabicUrduFontName,
@@ -26,7 +27,7 @@ export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSele
     setArabicUrduFontDisplayName,
     ffsArr,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isArabicUrduDefault,
     isAwami,
     handleClickArabicUrdu,
@@ -87,7 +88,7 @@ export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSele
     };
 
   const fontMenuItemProps = {
-    selectedFontClass,
+    adjSelectedFontClass,
   };
   
   /** Build dropdown menus */
@@ -143,7 +144,7 @@ export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSele
     fontDisplayName: arabicUrduFontDisplayName,
     fontSize: arabicUrduFontSize,
     lineHeight: arabicUrduLineHeight,
-    isGraphiteAssumed,
+    isGraphite,
     // ffsArr: arabicUrduFfsArr, // Removing wdsp and punc for now by using awamiFfsLessPuncAndSpacing.
     exampleRegex: regexArabicUrdu,
     setExampleArabicUrdu,
@@ -159,7 +160,7 @@ export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSele
   return (
     <Grid2 container spacing={2}>
       <Grid2  size={12}>
-        <div className={selectedFontClass} style={{ fontSize: '100%' }}>
+        <div className={adjSelectedFontClass} style={{ fontSize: '100%' }}>
           <Stack direction="row">
             <FormControl fullWidth style={{maxWidth: 400, minWidth: 400}} size="small">
                 <InputLabel shrink={true} id="select-arabic-urdu-font-label" htmlFor="select-arabic-urdu-font-id" sx={sx.inputLabel}>
@@ -184,7 +185,7 @@ export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSele
             </FormControl>
             {!isArabicUrduDefault &&  
               <Tooltip 
-                title={`Awami Nastaliq (${doI18n("pages:core-settings:if_not_firefox", i18nRef.current)})`}
+                title={`Awami Nastaliq (${doI18n("pages:core-settings:replace_awami", i18nRef.current)})`}
                 placement="right"
                 arrow
               >
@@ -193,17 +194,17 @@ export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSele
             }
             {isAwami &&
               <Tooltip
-                title={isGraphiteAssumed ? doI18n("pages:core-settings:replace_awami", i18nRef.current) : doI18n("pages:core-settings:replace_noto", i18nRef.current)}
+                title={(isGraphite ? doI18n("pages:core-settings:replace_awami", i18nRef.current) : doI18n("pages:core-settings:replace_noto", i18nRef.current)) + " " + (!isGraphite && isFirefox ? doI18n("pages:core-settings:graphite_is_off", i18nRef.current) : doI18n("pages:core-settings:graphite_support", i18nRef.current))}
                 placement="right"
               >
-                { isGraphiteAssumed ?
-                  <InfoIcon color="secondary "style={{paddingLeft: '9px', margin: 'auto 0' }} />
+                { isGraphite ?
+                  <InfoIcon color="secondary" style={{paddingLeft: '9px', margin: 'auto 0' }} />
                   :
                   <WarningSharpIcon style={{ color: 'yellow', background: 'black', margin: 'auto 9px' }} />
                 }
               </Tooltip>
             }
-            {isAwami && !isGraphiteAssumed && <div className={selectedFontClass} style={{margin: 'auto 0',fontSize: '100%' }}>{doI18n("pages:core-settings:best_with", i18nRef.current)}</div>}
+            {isAwami && !isGraphite && <div className={adjSelectedFontClass} style={{margin: 'auto 0',fontSize: '100%' }}>{doI18n("pages:core-settings:best_with", i18nRef.current)} {isFirefox ? doI18n("pages:core-settings:graphite_is_off", i18nRef.current) : doI18n("pages:core-settings:graphite_support", i18nRef.current)}</div>}
             {showArabicUrduFeatures && <FontFeaturesArabicUrdu {...fontFeaturesArabicUrduProps} />}
           </Stack>
         </div>
@@ -212,7 +213,7 @@ export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSele
         <Box sx={{ padding: '10pt 0 5pt 20pt' }}>
           {showArabicUrduTextArea &&
             <TextareaAutosize
-              minRows={isGraphiteAssumed ? 4 : 1}
+              minRows={isGraphite ? 4 : 1}
               id="exampleArabicUrdu"
               type="text"
               onChange={handleExampleArabicUrdu}
@@ -239,8 +240,10 @@ export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSele
 }
 
 BlendedFontArabicUrduSelection.propTypes = {
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
+  /** Is the Browser Firefox? */
+  isFirefox: PropTypes.bool.isRequired,
   /** Selected Arabic/Urdu Font Class Substring */
   selectedArabicUrduFontClassSubstr: PropTypes.string,
   /** Set Selected Arabic/Urdu Font Class Substring */
@@ -260,7 +263,7 @@ BlendedFontArabicUrduSelection.propTypes = {
   /** Unicode ranges for RegEx by script type for editable examples */
   unicodeRanges: PropTypes.array.isRequired,
   /** Selected Font Class */
-  selectedFontClass: PropTypes.string.isRequired,
+  adjSelectedFontClass: PropTypes.string.isRequired,
   /** Is ArabicUrdu set to Default? */
   isArabicUrduDefault: PropTypes.bool.isRequired,
   /** Is an Awami Nastaliq Font Selected? */

--- a/src/components/BlendedFontBaseSelection.jsx
+++ b/src/components/BlendedFontBaseSelection.jsx
@@ -14,7 +14,7 @@ import FontFeaturesBase from "./FontFeaturesBase";
 export default function BlendedFontBaseSelection(blendedFontBaseSelectionProps) {
   const { i18nRef } = useContext(I18nContext);
   const {
-    isGraphiteAssumed,
+    isGraphite,
     selectedBaseFontClassSubstr,
     setSelectedBaseFontClassSubstr,
     selectedHebrewFontClassSubstr,
@@ -30,7 +30,7 @@ export default function BlendedFontBaseSelection(blendedFontBaseSelectionProps) 
     setBaseFontDisplayName,
     ffsArr,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isBaseDefault,
     handleClickBase,
   } = blendedFontBaseSelectionProps;
@@ -77,11 +77,15 @@ export default function BlendedFontBaseSelection(blendedFontBaseSelectionProps) 
       setBaseFontName(baseName);
     };
 
+  const fontMenuItemProps = {
+    adjSelectedFontClass,
+  };
+
   /** Build dropdown menus */
   const WebFontsSelectableBase =
     webFontsBase.map((font, index) => (
         <MenuItem key={index} value={font.id} dense>
-            <FontMenuItem font={font}/>
+            <FontMenuItem font={font} {...fontMenuItemProps} />
         </MenuItem>
     ));
   
@@ -133,7 +137,7 @@ export default function BlendedFontBaseSelection(blendedFontBaseSelectionProps) 
     fontDisplayName: baseFontDisplayName,
     fontSize: baseFontSize,
     lineHeight: baseLineHeight,
-    isGraphiteAssumed,
+    isGraphite,
     ffsArr: baseFfsArr, // Options
     exampleRegex: regexBase,
     setExampleBase,
@@ -149,7 +153,7 @@ export default function BlendedFontBaseSelection(blendedFontBaseSelectionProps) 
   return (
     <Grid2 container spacing={2}>
       <Grid2 size={12}>
-        <div className={selectedFontClass} style={{ fontSize: '100%'}}>
+        <div className={adjSelectedFontClass} style={{ fontSize: '100%'}}>
           <Stack direction="row">
             <FormControl fullWidth style={{maxWidth: 400, minWidth: 400}} size="small">
                 <InputLabel id="select-base-font-label" htmlFor="select-base-font-id" sx={sx.inputLabel}>
@@ -212,8 +216,8 @@ export default function BlendedFontBaseSelection(blendedFontBaseSelectionProps) 
 }
 
 BlendedFontBaseSelection.propTypes = {
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
   /** Selected Base Font Class Substring */
   selectedBaseFontClassSubstr: PropTypes.string,
   /** Set Selected Base Font Class Substring */
@@ -247,7 +251,7 @@ BlendedFontBaseSelection.propTypes = {
   /** Is a font set for Base? */
   isBaseOn: PropTypes.bool.isRequired,
   /** Selected Font Class */
-  selectedFontClass: PropTypes.string.isRequired,
+  adjSelectedFontClass: PropTypes.string.isRequired,
   /** Is Base Font set to Default? */
   isBaseDefault: PropTypes.bool.isRequired,
   /** Handle Click Base Font Reset to Default */

--- a/src/components/BlendedFontGreekSelection.jsx
+++ b/src/components/BlendedFontGreekSelection.jsx
@@ -18,7 +18,7 @@ export default function BlendedFontGreekSelection(blendedFontGreekSelectionProps
     setGreekFontName,
     webFontsGreek,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isGreekDefault,
     handleClickGreek,
   } = blendedFontGreekSelectionProps;
@@ -37,9 +37,10 @@ export default function BlendedFontGreekSelection(blendedFontGreekSelectionProps
   };
 
   const fontMenuItemProps = {
-    selectedFontClass,
+    adjSelectedFontClass,
   };
-  
+
+  /** Build dropdown menus */
   const WebFontsSelectableGreek =
   webFontsGreek.map((font, index) => (
     <MenuItem key={index} value={font.id} dense>
@@ -66,7 +67,7 @@ export default function BlendedFontGreekSelection(blendedFontGreekSelectionProps
   return (
     <Grid2 container spacing={2}>
       <Grid2  size={12}>
-        <div className={selectedFontClass} style={{ fontSize: '100%'}}>
+        <div className={adjSelectedFontClass} style={{ fontSize: '100%'}}>
           <Stack direction="row">
             <FormControl fullWidth style={{maxWidth: 400, minWidth: 400}} size="small">
                 <InputLabel shrink={true} id="select-greek-font-label" htmlFor="select-greek-font-id" sx={sx.inputLabel}>
@@ -140,7 +141,7 @@ BlendedFontGreekSelection.propTypes = {
   /** Unicode ranges for RegEx by script type for editable examples */
   unicodeRanges: PropTypes.array.isRequired,
   /** Selected Font Class */
-  selectedFontClass: PropTypes.string.isRequired,
+  adjSelectedFontClass: PropTypes.string.isRequired,
   /** Is Greek set to Default? */
   isGreekDefault: PropTypes.bool.isRequired,
   /** Handle Click Greek Reset to Default */

--- a/src/components/BlendedFontHebrewSelection.jsx
+++ b/src/components/BlendedFontHebrewSelection.jsx
@@ -18,7 +18,7 @@ export default function BlendedFontHebrewSelection(blendedFontHebrewSelectionPro
     setHebrewFontName,
     webFontsHebrew,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isHebrewDefault,
     handleClickHebrew,
   } = blendedFontHebrewSelectionProps;
@@ -37,7 +37,7 @@ export default function BlendedFontHebrewSelection(blendedFontHebrewSelectionPro
     };
 
   const fontMenuItemProps = {
-    selectedFontClass,
+    adjSelectedFontClass,
   };
 
   /** Build dropdown menus */
@@ -67,7 +67,7 @@ export default function BlendedFontHebrewSelection(blendedFontHebrewSelectionPro
   return (
     <Grid2 container spacing={2}>
       <Grid2 size={12} color="secondary" sx={{ borderTop: 1}}>
-        <div className={selectedFontClass} style={{ fontSize: '100%'}}>
+        <div className={adjSelectedFontClass} style={{ fontSize: '100%'}}>
           <Stack direction="row">
             <FormControl fullWidth style={{maxWidth: 400, minWidth: 400}} size="small">
                 <InputLabel shrink={true} id="select-hebrew-font-label" htmlFor="select-hebrew-font-id" sx={sx.inputLabel}>
@@ -142,7 +142,7 @@ BlendedFontHebrewSelection.propTypes = {
   /** Unicode ranges for RegEx by script type for editable examples */
   unicodeRanges: PropTypes.array.isRequired,
   /** Selected Font Class */
-  selectedFontClass: PropTypes.string.isRequired,
+  adjSelectedFontClass: PropTypes.string.isRequired,
   /** Is Hebrew set to Default? */
   isHebrewDefault: PropTypes.bool.isRequired,
   /** Handle Click Hebrew Reset to Default */

--- a/src/components/BlendedFontMyanmarSelection.jsx
+++ b/src/components/BlendedFontMyanmarSelection.jsx
@@ -3,6 +3,7 @@ import { useEffect, useContext, useState } from "react";
 import PropTypes from 'prop-types';
 import { Grid2, Box, InputLabel, MenuItem, FormControl, Select, Stack, TextareaAutosize, Tooltip } from "@mui/material";
 import RestoreIcon from '@mui/icons-material/Restore';
+import InfoIcon from '@mui/icons-material/Info';
 import { i18nContext as I18nContext, doI18n, postEmptyJson } from "pithekos-lib";
 import { useDetectDir } from "font-detect-rhl";
 import { renderToString } from 'react-dom/server';
@@ -14,7 +15,8 @@ import FontFeaturesMyanmar from "./FontFeaturesMyanmar";
 export default function BlendedFontMyanmarSelection(blendedFontMyanmarSelectionProps) {
   const { i18nRef } = useContext(I18nContext);
   const {
-    isGraphiteAssumed,
+    isGraphite,
+    isFirefox,
     selectedMyanmarFontClassSubstr,
     setSelectedMyanmarFontClassSubstr,
     myanmarFontName,
@@ -26,8 +28,9 @@ export default function BlendedFontMyanmarSelection(blendedFontMyanmarSelectionP
     setMyanmarFontDisplayName,
     ffsArr,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isMyanmarDefault,
+    isPadauk,
     handleClickMyanmar,
   } = blendedFontMyanmarSelectionProps;
 
@@ -73,7 +76,7 @@ export default function BlendedFontMyanmarSelection(blendedFontMyanmarSelectionP
     };
 
   const fontMenuItemProps = {
-    selectedFontClass,
+    adjSelectedFontClass,
   };
 
   /** Build dropdown menus */
@@ -129,7 +132,7 @@ export default function BlendedFontMyanmarSelection(blendedFontMyanmarSelectionP
     fontDisplayName: myanmarFontDisplayName,
     fontSize: myanmarFontSize,
     lineHeight: myanmarLineHeight,
-    isGraphiteAssumed,
+    isGraphite,
     ffsArr: myanmarFfsArr,  // Options
     exampleRegex: regexMyanmar,
     setExampleMyanmar,
@@ -143,7 +146,7 @@ export default function BlendedFontMyanmarSelection(blendedFontMyanmarSelectionP
   return (
     <Grid2 container spacing={2}>
       <Grid2  size={12}>
-        <div className={selectedFontClass} style={{ fontSize: '100%'}}>
+        <div className={adjSelectedFontClass} style={{ fontSize: '100%'}}>
           <Stack direction="row">
             <FormControl fullWidth style={{maxWidth: 400, minWidth: 400}} size="small">
                 <InputLabel shrink={true} id="select-myanmar-font-label" htmlFor="select-myanmar-font-id" sx={sx.inputLabel}>
@@ -172,6 +175,14 @@ export default function BlendedFontMyanmarSelection(blendedFontMyanmarSelectionP
                 arrow
               >
                 <RestoreIcon color="secondary" sx={{ cursor: 'pointer' }} style={{ paddingLeft: '9px', margin: 'auto 0' }} onClick={handleClickMyanmar} />
+              </Tooltip>
+            }
+            {!isGraphite && isPadauk &&
+              <Tooltip
+                title={doI18n("pages:core-settings:padauk_tip", i18nRef.current) + " " + (isFirefox ? doI18n("pages:core-settings:graphite_is_off", i18nRef.current) : doI18n("pages:core-settings:graphite_support", i18nRef.current))}
+                placement="right"
+              >
+                <InfoIcon color="secondary" style={{ paddingLeft: '9px', margin: 'auto 0' }} />
               </Tooltip>
             }
             {showMyanmarFeatures && <FontFeaturesMyanmar {...fontFeaturesMyanmarProps} />}
@@ -209,8 +220,10 @@ export default function BlendedFontMyanmarSelection(blendedFontMyanmarSelectionP
 }
 
 BlendedFontMyanmarSelection.propTypes = {
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
+  /** Is the Browser Firefox? */
+  isFirefox: PropTypes.bool.isRequired,
   /** Selected Myanmar Font Class Substring */
   selectedMyanmarFontClassSubstr: PropTypes.string,
   /** Set Selected Myanmar Font Class Substring */
@@ -234,9 +247,11 @@ BlendedFontMyanmarSelection.propTypes = {
   /** Unicode ranges for RegEx by script type for editable examples */
   unicodeRanges: PropTypes.array.isRequired,
   /** Selected Font Class */
-  selectedFontClass: PropTypes.string.isRequired,
+  adjSelectedFontClass: PropTypes.string.isRequired,
   /** Is Myanmar set to Default? */
   isMyanmarDefault: PropTypes.bool.isRequired,
+  /** Is a Padaul Font Selected? */
+  isPadauk: PropTypes.bool.isRequired,
   /** Handle Click Myanmar Reset to Default */
   handleClickMyanmar:  PropTypes.func.isRequired,
 };

--- a/src/components/BlendedFontsPage.jsx
+++ b/src/components/BlendedFontsPage.jsx
@@ -25,9 +25,10 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
   const {
     fontMenu,
     setFontMenu,
+    isGraphite,
   } = blendedFontsPageProps;
 
-  // Font Class Substrings
+    // Font Class Substrings
   const [selectedHebrewFontClassSubstr, setSelectedHebrewFontClassSubstr] = useState('');
   const [selectedGreekFontClassSubstr, setSelectedGreekFontClassSubstr] = useState('');
   const [selectedMyanmarFontClassSubstr, setSelectedMyanmarFontClassSubstr] = useState('');
@@ -103,19 +104,21 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
       ]);
     }
   },[baseFontDisplayName, i18nRef, prevBaseFontDisplayName, webFontsMyanmar.length]);
-  const isGraphiteAssumed = useAssumeGraphite({}); // Tests for Firefox; A different test can show if Graphite is enabled.
+  
+  const isFirefox = useAssumeGraphite({});
+
   useEffect(() => {
     if (!webFontsArabicUrdu.length || !baseFontDisplayName.length || prevBaseFontDisplayName !== baseFontDisplayName|| !arabicUrduFontDisplayName.length || prevArabicUrduFontDisplayName !== arabicUrduFontDisplayName) {
       setWebFontsArabicUrdu([
-        { display_name: isGraphiteAssumed ? 'Awami Nastaliq 3.300' : 'Noto Nastaliq Urdu 4.000', id: 'Pankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrdu', name: 'Pankosmia-Awami Nastaliq', settings_id: 'Awami Nastaliq', shortlist: isGraphiteAssumed || ( !isGraphiteAssumed && selectedArabicUrduFontClassSubstr.toString() !== 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu' && selectedArabicUrduFontClassSubstr.toString() !== 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu' && selectedArabicUrduFontClassSubstr.toString() !== 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu' ), example: 'مثال'},
-        { display_name: isGraphiteAssumed ? 'Awami Nastaliq Medium 3.300' : 'Noto Nastaliq Urdu 4.000', id: 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu', name: 'Pankosmia-Awami Nastaliq Medium', settings_id: 'Awami Nastaliq', shortlist: selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu', example: 'مثال' },
-        { display_name: isGraphiteAssumed ? 'Awami Nastaliq Semi Bold 3.300' : 'Noto Nastaliq Urdu 4.000', id: 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu', name: 'Pankosmia-Awami Nastaliq Semi Bold', settings_id: 'Awami Nastaliq', shortlist: selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu', example: 'مثال' },
-        { display_name: isGraphiteAssumed ? 'Awami Nastaliq Extra Bold 3.300' : 'Noto Nastaliq Urdu 4.000', id: 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu', name: 'Pankosmia-Awami Nastaliq Extra Bold', settings_id: 'Awami Nastaliq', shortlist: selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu', example: 'مثال' },
+        { display_name: isGraphite ? 'Awami Nastaliq 3.300' : 'Noto Nastaliq Urdu 4.000', id: 'Pankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrdu', name: 'Pankosmia-Awami Nastaliq', settings_id: 'Awami Nastaliq', shortlist: isGraphite || ( !isGraphite && selectedArabicUrduFontClassSubstr.toString() !== 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu' && selectedArabicUrduFontClassSubstr.toString() !== 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu' && selectedArabicUrduFontClassSubstr.toString() !== 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu' ), example: 'مثال'},
+        { display_name: isGraphite ? 'Awami Nastaliq Medium 3.300' : 'Noto Nastaliq Urdu 4.000', id: 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu', name: 'Pankosmia-Awami Nastaliq Medium', settings_id: 'Awami Nastaliq', shortlist: selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu', example: 'مثال' },
+        { display_name: isGraphite ? 'Awami Nastaliq Semi Bold 3.300' : 'Noto Nastaliq Urdu 4.000', id: 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu', name: 'Pankosmia-Awami Nastaliq Semi Bold', settings_id: 'Awami Nastaliq', shortlist: selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu', example: 'مثال' },
+        { display_name: isGraphite ? 'Awami Nastaliq Extra Bold 3.300' : 'Noto Nastaliq Urdu 4.000', id: 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu', name: 'Pankosmia-Awami Nastaliq Extra Bold', settings_id: 'Awami Nastaliq', shortlist: selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu', example: 'مثال' },
         { display_name: 'Noto Naskh Arabic 2.018', id: 'Pankosmia-NotoNaskhArabic', name: 'Pankosmia-Noto Naskh Arabic', settings_id: '', shortlist: true, example: 'مثال' },
         { display_name: `${doI18n("pages:core-settings:base_font", i18nRef.current)} (${baseFontDisplayName})`, id: '', name: '', settings_id: '', shortlist: true, example: 'مثال' },
       ]);
     }
-  },[arabicUrduFontDisplayName, baseFontDisplayName, i18nRef, isGraphiteAssumed, prevArabicUrduFontDisplayName, prevBaseFontDisplayName, selectedArabicUrduFontClassSubstr, webFontsArabicUrdu.length]);
+  },[arabicUrduFontDisplayName, baseFontDisplayName, i18nRef, isGraphite, prevArabicUrduFontDisplayName, prevBaseFontDisplayName, selectedArabicUrduFontClassSubstr, webFontsArabicUrdu.length]);
   useEffect(() => {
     if (!webFontsBase.length || !baseFontDisplayName.length || prevBaseFontDisplayName !== baseFontDisplayName) {
       setWebFontsBase([
@@ -213,6 +216,12 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
     setSelectedFontClass(typographyRef.current.font_set);
   },[typographyRef]);
 
+  /**
+   * selectedFontClass is needed for isCurrentDefault and to set fontClassIdsArr without adjustment.
+   * adjSelectedFontClass is reshaped for the presence or absence of Graphite.
+   */
+  const adjSelectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
+
   // Font Settings Changes
   useEffect( () => {
     if(fontSetStr !== 'fonts-' && typographyRef.current.font_set !== fontSetStr) {
@@ -229,9 +238,9 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
   /** Awami Nastaliq requires Graphite, and Padauk has some Graphite-only features. */
   useEffect(() => {
     if (!ffsArr.length) {
-      setFfsArr(isGraphiteAssumed ? fontFeatureSettings : fontFeatureSettings.filter((name) => name.name !== 'Awami Nastaliq'));
+      setFfsArr(isGraphite ? fontFeatureSettings : fontFeatureSettings.filter((name) => name.name !== 'Awami Nastaliq'));
     }
-  },[isGraphiteAssumed, ffsArr.length]);
+  },[isGraphite, ffsArr.length]);
 
   /** Unicode ranges for RegEx by script type for editable examples */
   const unicodeRanges = [
@@ -242,7 +251,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
     { name: 'Base', id: 'base', unicode_range: '' },
   ];
 
-  const isCurrentDefault = selectedFontClass === "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus"  || ( !isGraphiteAssumed && (selectedFontClass === "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus" || selectedFontClass === "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus" || selectedFontClass === "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus" ));
+  const isCurrentDefault = selectedFontClass === "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus"  || ( !isGraphite && (selectedFontClass === "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus" || selectedFontClass === "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus" || selectedFontClass === "fonts-Pankosmia-CardoPankosmia-EzraSILPankosmia-PadaukPankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrduPankosmia-GentiumPlus" ));
 
   const webFontsBaseShortlist = webFontsBase.filter(font => font.shortlist);
   const webFontsArabicUrduShortlist = webFontsArabicUrdu.filter(font => font.shortlist);
@@ -294,7 +303,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
   };
 
   const fontMenuItemProps = {
-    selectedFontClass,
+    adjSelectedFontClass,
   };
 
   /** Build dropdown menus */
@@ -332,7 +341,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
   const isBaseDefault = selectedBaseFontClassSubstr.toString() === "Pankosmia-GentiumPlus";
   const isGreekDefault = selectedGreekFontClassSubstr.toString() === "Pankosmia-Cardo";
   const isHebrewDefault = selectedHebrewFontClassSubstr.toString() === "Pankosmia-EzraSIL";
-  const isArabicUrduDefault = selectedArabicUrduFontClassSubstr.toString() === "Pankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrdu" || ( !isGraphiteAssumed && (selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu' || selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu' || selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu' ));
+  const isArabicUrduDefault = selectedArabicUrduFontClassSubstr.toString() === "Pankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrdu" || ( !isGraphite && (selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu' || selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu' || selectedArabicUrduFontClassSubstr.toString() === 'Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu' ));
   const isMyanmarDefault = selectedMyanmarFontClassSubstr.toString() === "Pankosmia-Padauk";
 
   const handleClickBase = () => {
@@ -395,9 +404,12 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
   const isAwami = selectedArabicUrduFontClassSubstr.toString() !== '' && selectedArabicUrduFontClassSubstr.toString() !== 'Pankosmia-NotoNaskhArabic';
   const adjHeight = arabicUrduFontDisplayName.toString().includes("Awami Nastaliq") ? '1.75' : '';
 
+  const isPadauk = selectedMyanmarFontClassSubstr.toString() !== '';
+
   /** ArabicUrdu props patterns differ. */
   const blendedFontArabicUrduSelectionProps = {
-    isGraphiteAssumed,
+    isGraphite,
+    isFirefox,
     selectedArabicUrduFontClassSubstr,
     setSelectedArabicUrduFontClassSubstr,
     arabicUrduFontName,
@@ -407,13 +419,14 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
     setArabicUrduFontDisplayName,
     ffsArr,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isArabicUrduDefault,
     isAwami,
     handleClickArabicUrdu,
   };
   const blendedFontMyanmarSelectionProps = {
-    isGraphiteAssumed,
+    isGraphite,
+    isFirefox,
     selectedMyanmarFontClassSubstr,
     setSelectedMyanmarFontClassSubstr,
     myanmarFontName,
@@ -425,8 +438,9 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
     setMyanmarFontDisplayName,
     ffsArr,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isMyanmarDefault,
+    isPadauk,
     handleClickMyanmar,
   };
   const blendedFontGreekSelectionProps = {
@@ -441,7 +455,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
     // setGreekFontDisplayName,
     // ffsArr,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isGreekDefault,
     handleClickGreek,
   };
@@ -457,12 +471,12 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
     // setHebrewFontDisplayName,
     // ffsArr,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isHebrewDefault,
     handleClickHebrew,
   };
   const blendedFontBaseSelectionProps = {
-    isGraphiteAssumed,
+    isGraphite,
     selectedBaseFontClassSubstr,
     setSelectedBaseFontClassSubstr,
     selectedHebrewFontClassSubstr,
@@ -478,7 +492,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
     setBaseFontDisplayName,
     ffsArr,
     unicodeRanges,
-    selectedFontClass,
+    adjSelectedFontClass,
     isBaseDefault,
     handleClickBase,
   };
@@ -492,7 +506,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
             <FormControl  component="fieldset">
               <Grid2 container sx={{}}>
                 <Grid2 item>
-                  <div className={selectedFontClass} style={{ fontSize: '100%'}}>
+                  <div className={adjSelectedFontClass} style={{ fontSize: '100%'}}>
                     <Stack direction="column" spacing={2}>
                       <div style={{ display: 'flex', flexDirection: 'row' }}>
                         <FormControl fullWidth style={{maxWidth: 400, minWidth: 400}} size="small">
@@ -613,7 +627,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
                         </FormControl>
                         {!isArabicUrduDefault &&  
                           <Tooltip 
-                            title={`Awami Nastaliq (${doI18n("pages:core-settings:if_not_firefox", i18nRef.current)})`}
+                            title={`Awami Nastaliq (${doI18n("pages:core-settings:replace_awami", i18nRef.current)})`}
                             placement="right"
                             arrow
                           >
@@ -623,17 +637,17 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
                         <MoreHorizIcon color="secondary" sx={{ cursor: 'pointer' }} style={{paddingLeft: '9px', margin: 'auto 0' }} onClick={handleClickArabicUrduMore} />
                         {isAwami &&
                           <Tooltip
-                            title={isGraphiteAssumed ? doI18n("pages:core-settings:replace_awami", i18nRef.current) : doI18n("pages:core-settings:replace_noto", i18nRef.current)}
+                            title={(isGraphite ? doI18n("pages:core-settings:replace_awami", i18nRef.current) : doI18n("pages:core-settings:replace_noto", i18nRef.current)) + " " + (!isGraphite && isFirefox ? doI18n("pages:core-settings:graphite_is_off", i18nRef.current) : doI18n("pages:core-settings:graphite_support", i18nRef.current))}
                             placement="right"
                           >
-                            { isGraphiteAssumed ?
+                            { isGraphite ?
                               <InfoIcon color="secondary" style={{ paddingLeft: '9px', margin: 'auto 0' }} />
                               :
                               <WarningSharpIcon style={{ color: 'yellow', background: 'black', margin: 'auto 9px' }} />
                             }
                           </Tooltip>
                         }
-                        {isAwami && !isGraphiteAssumed && <div className={selectedFontClass} style={{margin: 'auto 0',fontSize: '100%' }}>{doI18n("pages:core-settings:best_with", i18nRef.current)}</div>}
+                        {isAwami && !isGraphite && <div className={adjSelectedFontClass} style={{margin: 'auto 0',fontSize: '100%' }}>{doI18n("pages:core-settings:best_with", i18nRef.current)} {isFirefox ? doI18n("pages:core-settings:graphite_is_off", i18nRef.current) : doI18n("pages:core-settings:graphite_support", i18nRef.current)}</div>}
                       </div>
                       <div style={{ display: 'flex', flexDirection: 'row' }}>
                         <FormControl fullWidth style={{maxWidth: 400, minWidth: 400}} size="small">
@@ -666,8 +680,16 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
                           </Tooltip>
                         }
                         <MoreHorizIcon color="secondary" sx={{ cursor: 'pointer' }} style={{paddingLeft: '9px', margin: 'auto 0' }} onClick={handleClickMyanmarMore} />
+                        {!isGraphite && isPadauk &&
+                          <Tooltip
+                            title={doI18n("pages:core-settings:padauk_tip", i18nRef.current) + " " + (isFirefox ? doI18n("pages:core-settings:graphite_is_off", i18nRef.current) : doI18n("pages:core-settings:graphite_support", i18nRef.current))}
+                            placement="right"
+                          >
+                            <InfoIcon color="secondary" style={{ paddingLeft: '9px', margin: 'auto 0' }} />
+                          </Tooltip>
+                        }
                       </div>
-                      <div className={selectedFontClass} style={{ display: 'flex', flexDirection: 'row', fontSize: '100%' }}>
+                      <div className={adjSelectedFontClass} style={{ display: 'flex', flexDirection: 'row', fontSize: '100%' }}>
                         {!isCurrentDefault &&  
                           <Tooltip 
                             title={
@@ -675,7 +697,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
                                   {doI18n("pages:core-settings:base_font", i18nRef.current)}: Gentium Plus<br /><br />
                                   {doI18n("pages:core-settings:select_greekscript", i18nRef.current)}: Cardo<br /><br />
                                   {doI18n("pages:core-settings:select_hebrewscript", i18nRef.current)}: Ezra SIL<br /><br />
-                                  {doI18n("pages:core-settings:select_arabicurduscript", i18nRef.current)}: {`Awami Nastaliq (${doI18n("pages:core-settings:if_not_firefox", i18nRef.current)})`}<br /><br />
+                                  {doI18n("pages:core-settings:select_arabicurduscript", i18nRef.current)}: {`Awami Nastaliq (${doI18n("pages:core-settings:replace_awami", i18nRef.current)})`}<br /><br />
                                   {doI18n("pages:core-settings:select_myanmarscript", i18nRef.current)}: Padauk
                               </Fragment>
                             }
@@ -753,6 +775,8 @@ BlendedFontsPage.propTypes = {
   fontMenu: PropTypes.string.isRequired,
   /** Set Font Menu */
   setFontMenu: PropTypes.func.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired
 }
 
 BlendedFontsPage.defaultProps = {

--- a/src/components/BlendedFontsPage.jsx
+++ b/src/components/BlendedFontsPage.jsx
@@ -218,7 +218,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
 
   /**
    * selectedFontClass is needed for isCurrentDefault and to set fontClassIdsArr without adjustment.
-   * adjSelectedFontClass is reshaped for the presence or absence of Graphite.
+   * adjSelectedFontClass reshapes selectedFontClass if Graphite is absent.
    */
   const adjSelectedFontClass = isGraphite ? typographyRef.current.font_set : typographyRef.current.font_set.replace(/Pankosmia-AwamiNastaliq(.*)Pankosmia-NotoNastaliqUrdu/ig, 'Pankosmia-NotoNastaliqUrdu');
 

--- a/src/components/FontFeaturesArabicUrdu.jsx
+++ b/src/components/FontFeaturesArabicUrdu.jsx
@@ -20,7 +20,7 @@ export default function FontFeaturesArabicUrdu(fontFeaturesArabicUrduProps) {
     fontDisplayName,
     fontSize,
     lineHeight,
-    isGraphiteAssumed,
+    isGraphite,
     // ffsArr, // Options
     exampleRegex,
     setExampleArabicUrdu, // Example text
@@ -72,7 +72,7 @@ export default function FontFeaturesArabicUrdu(fontFeaturesArabicUrduProps) {
 
   const fontSettingsArrProps = {
     ffsArr: awamiFfsLessPuncAndSpacing, // Removing wdsp and punc for now by using awamiFfsLessPuncAndSpacing.
-    isGraphiteAssumed,
+    isGraphite,
   };
 
   const fontSettingsArr = FontFeatureDefaults(fontSettingsArrProps);
@@ -172,7 +172,7 @@ export default function FontFeaturesArabicUrdu(fontFeaturesArabicUrduProps) {
     radioLeftMargin,
     labelStyle,
     diffStyle,
-    isGraphiteAssumed,
+    isGraphite,
     ffsArr: awamiFfsLessPuncAndSpacing, // Current unicode ranges always result in 'punc 2' (Latin); Removing that option for now.
   };
 
@@ -223,8 +223,8 @@ FontFeaturesArabicUrdu.propTypes = {
   fontSize: PropTypes.string,
   /** Line Height */
   lineHeight: PropTypes.string,
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
   /** Font Feature Settings Array (Options)*/
   // ffsArr: PropTypes.array.isRequired, : // Removing wdsp and punc for now by using awamiFfsLessPuncAndSpacing.
   /** Example Regular Expression */

--- a/src/components/FontFeaturesBase.jsx
+++ b/src/components/FontFeaturesBase.jsx
@@ -19,7 +19,7 @@ export default function FontFeaturesBase(fontFeaturesBaseProps) {
     fontDisplayName,
     fontSize,
     lineHeight,
-    isGraphiteAssumed,
+    isGraphite,
     ffsArr, // Options
     exampleRegex,
     setExampleBase, // Example text
@@ -71,7 +71,7 @@ export default function FontFeaturesBase(fontFeaturesBaseProps) {
 
   const fontSettingsArrProps = {
     ffsArr, 
-    isGraphiteAssumed,
+    isGraphite,
   };
 
   const fontSettingsArr = FontFeatureDefaults(fontSettingsArrProps);
@@ -171,7 +171,7 @@ export default function FontFeaturesBase(fontFeaturesBaseProps) {
     radioLeftMargin,
     labelStyle,
     diffStyle,
-    isGraphiteAssumed,
+    isGraphite,
     ffsArr,
   };
 
@@ -222,8 +222,8 @@ FontFeaturesBase.propTypes = {
   fontSize: PropTypes.string,
   /** Line Height */
   lineHeight: PropTypes.string,
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
   /** Font Feature Settings Array (Options)*/
   ffsArr: PropTypes.array.isRequired,
   /** Example Regular Expression */

--- a/src/components/FontFeaturesMyanmar.jsx
+++ b/src/components/FontFeaturesMyanmar.jsx
@@ -19,7 +19,7 @@ export default function FontFeaturesMyanmar(fontFeaturesMyanmarProps) {
     fontDisplayName,
     fontSize,
     lineHeight,
-    isGraphiteAssumed,
+    isGraphite,
     ffsArr, // Options
     exampleRegex,
     setExampleMyanmar, // Example text
@@ -71,7 +71,7 @@ export default function FontFeaturesMyanmar(fontFeaturesMyanmarProps) {
 
   const fontSettingsArrProps = {
     ffsArr, 
-    isGraphiteAssumed,
+    isGraphite,
   };
 
   const fontSettingsArr = FontFeatureDefaults(fontSettingsArrProps);
@@ -171,7 +171,7 @@ export default function FontFeaturesMyanmar(fontFeaturesMyanmarProps) {
     radioLeftMargin,
     labelStyle,
     diffStyle,
-    isGraphiteAssumed,
+    isGraphite,
     ffsArr,
   };
 
@@ -222,8 +222,8 @@ FontFeaturesMyanmar.propTypes = {
   fontSize: PropTypes.string,
   /** Line Height */
   lineHeight: PropTypes.string,
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
   /** Font Feature Settings Array (Options)*/
   ffsArr: PropTypes.array.isRequired,
   /** Example Regular Expression */

--- a/src/components/FontMenuItem.jsx
+++ b/src/components/FontMenuItem.jsx
@@ -2,7 +2,7 @@ import { PropTypes } from "prop-types";
 import { Typography } from "@mui/material";
 
 export default function FontShortlistMenuItem(fontCheckboxItemProps) {
-  const { font, selectedFontClass } = fontCheckboxItemProps;
+  const { font, adjSelectedFontClass } = fontCheckboxItemProps;
 
   const styles = {
     hr: {
@@ -26,7 +26,7 @@ export default function FontShortlistMenuItem(fontCheckboxItemProps) {
         style={styles.menuItem}
       >
         <Typography
-          class={selectedFontClass}
+          class={adjSelectedFontClass}
           style={{ fontSize: '100%'}}
           noWrap
           variant="body2"
@@ -49,6 +49,7 @@ export default function FontShortlistMenuItem(fontCheckboxItemProps) {
 }
 
 FontShortlistMenuItem.propTypes = {
+  /** Font */
   font: PropTypes.shape({
     display_name: PropTypes.string,
     id: PropTypes.string,
@@ -56,4 +57,6 @@ FontShortlistMenuItem.propTypes = {
     settings_id: PropTypes.string,
     example: PropTypes.string,
   }),
+  /** Adjusted Selected Font Class */
+  adjSelectedFontClass: PropTypes.string,
 };

--- a/src/components/GraphiteTest.jsx
+++ b/src/components/GraphiteTest.jsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+import {useDetectRender} from 'font-detect-rhl';
+
+export default function GraphiteTest() {
+
+  const [testFont, setTestFont] = useState('');
+  const [hasRunOnce, setHasRunOnce] = useState(false);
+
+  const font = new FontFace("Pankosmia-GraphiteTest", "url(/webfonts/awami/AwamiNastaliq-Regular.woff2)", {
+    style: "normal",
+    weight: "normal",
+  });
+
+  document.fonts.add(font);
+  
+  async function check() {
+    await font.load();
+    setTestFont('Pankosmia-GraphiteTest');
+  }
+
+  useEffect ( () => {
+    if (!hasRunOnce) {
+      check();
+      setHasRunOnce(true);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[hasRunOnce])
+
+  const testFontArray = [{ name: testFont }];
+  const renderType = useDetectRender({fonts:testFontArray});
+  const isGraphite = renderType[0].detectedRender === 'RenderingGraphite';
+
+  return isGraphite;
+}

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,9 +1,10 @@
-import { useContext, useState, useEffect } from "react"
+import { useContext, useState, useEffect } from "react";
 import PropTypes from 'prop-types';
 import { Tabs, Tab, Box, Grid2, Switch } from "@mui/material";
-import {debugContext, i18nContext, doI18n, getJson, getAndSetJson, postEmptyJson} from "pithekos-lib";
+import { debugContext, i18nContext, doI18n, getJson, getAndSetJson, postEmptyJson } from "pithekos-lib";
 import BlendedFontsPage from "./BlendedFontsPage";
 import LanguageSelection from "./LanguageSelection";
+import GraphiteTest from "./GraphiteTest";
 
 const CustomTabPanel = (props) => {
   const { children, value, index, ...other } = props;
@@ -265,10 +266,13 @@ export default function Settings() {
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
+  
+  const isGraphite = GraphiteTest()
 
   const blendedFontsPageProps = {
     fontMenu,
     setFontMenu,
+    isGraphite,
   };
 
   const onClickFontMenu = (event) => {

--- a/src/components/helpers/FontFeatureDefaults.jsx
+++ b/src/components/helpers/FontFeatureDefaults.jsx
@@ -5,7 +5,7 @@ import { renderToString } from 'react-dom/server';
 export default function FontFeatureDefaults(FontFeatureDefaultsProps) {
   const {
     ffsArr,
-    isGraphiteAssumed,
+    isGraphite,
   } = FontFeatureDefaultsProps;
 
   // This creates an array of font settings names and default values
@@ -13,11 +13,11 @@ export default function FontFeatureDefaults(FontFeatureDefaultsProps) {
     <div key={fontIndex}>
       {font.categories.map((categories, categoriesIndex) => {
         return (<div key={categoriesIndex}>
-          {font.categories[categoriesIndex].category.filter(item => isGraphiteAssumed ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((category, categoryIndex) => {
+          {font.categories[categoriesIndex].category.filter(item => isGraphite ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((category, categoryIndex) => {
             return (<div key={categoryIndex}>
               {category.sets.map((sets, setsIndex) => {
                 return (<div key={setsIndex}>
-                  {category.sets[setsIndex].set.filter(item => isGraphiteAssumed ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((set, setIndex) => {
+                  {category.sets[setsIndex].set.filter(item => isGraphite ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((set, setIndex) => {
                       return (<div key={setIndex}>
                         [~name~: ~{set.name}~, ~value~: {set.default}],
                       </div>)
@@ -29,7 +29,7 @@ export default function FontFeatureDefaults(FontFeatureDefaultsProps) {
       </div>)
       })}
     </div>
-  )), [ffsArr, isGraphiteAssumed]);
+  )), [ffsArr, isGraphite]);
   // convert jsx return to string and remove html tags and attributes (e.g., div's)
   const fontSettingsStr = renderToString(fontSettingsJsx).replace(/(<([^>]+)>)/ig, '');
   // remove the last comma, change [] to {} and ~ to " and convert string to an array of objects
@@ -39,8 +39,8 @@ export default function FontFeatureDefaults(FontFeatureDefaultsProps) {
 }
 
 FontFeatureDefaults.propTypes = {
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
   /** Array of Font Feature Settings Options */
   ffsArr: PropTypes.array.isRequired,
 };

--- a/src/components/helpers/FontFeatureSettings.jsx
+++ b/src/components/helpers/FontFeatureSettings.jsx
@@ -13,7 +13,7 @@ export default function FontFeatureSettings(fontFeatureSettingsProps) {
     radioLeftMargin,
     labelStyle,
     diffStyle,
-    isGraphiteAssumed,
+    isGraphite,
     ffsArr, // Possible options for the ffsId from fontFeatureSettings from font-detect-rhl 
   } = fontFeatureSettingsProps;
 
@@ -54,12 +54,12 @@ export default function FontFeatureSettings(fontFeatureSettingsProps) {
     <div key={fontIndex}>
       {font.categories.map((categories, categoriesIndex) => {
         return (<div key={categoriesIndex}>
-          {font.categories[categoriesIndex].category.filter(item => isGraphiteAssumed ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((category, categoryIndex) => {
+          {font.categories[categoriesIndex].category.filter(item => isGraphite ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((category, categoryIndex) => {
             return (<div key={categoryIndex}>
               <h1 style={{ textAlign: 'center', color:'purple'}}>{fontDisplayName}: {category.name}</h1>
               {category.sets.map((sets, setsIndex) => {
                 return (<div key={setsIndex}>
-                  {category.sets[setsIndex].set.filter(item => isGraphiteAssumed ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((set, setIndex) => {
+                  {category.sets[setsIndex].set.filter(item => isGraphite ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((set, setIndex) => {
                     return (<div key={setIndex}>
                       <FormLabel id={set.id}><div style={labelDivStyle}><mark style={labelMarkStyle}><br />{set.title}</mark></div></FormLabel>
                       <RadioGroup
@@ -93,7 +93,7 @@ export default function FontFeatureSettings(fontFeatureSettingsProps) {
         </div>)
       })}
     </div>
-  )), [count, diffStyle, ffsArr, fontDisplayName, fontSettings, handleChange, isGraphiteAssumed, labelDivStyle, labelMarkStyle, labelStyle, placementDir, radioColor, radioLeftMargin, radioRightMargin, tooltipPosition]);
+  )), [count, diffStyle, ffsArr, fontDisplayName, fontSettings, handleChange, isGraphite, labelDivStyle, labelMarkStyle, labelStyle, placementDir, radioColor, radioLeftMargin, radioRightMargin, tooltipPosition]);
 
   return featureSettings;
 }
@@ -115,8 +115,8 @@ FontFeatureSettings.propTypes = {
   labelStyle: PropTypes.object,
   /** Difference Style */
   diffStyle: PropTypes.string,
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
   /** Array of Font Feature Settings Options */
   ffsArr: PropTypes.array.isRequired,
 };

--- a/src/components/helpers/RadioLabelText.jsx
+++ b/src/components/helpers/RadioLabelText.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 export default function RadioLabelText(RadioLabelTextProps) {
   const {
     ffsArr,
-    isGraphiteAssumed,
+    isGraphite,
   } = RadioLabelTextProps;
 
   // Get radio label text
@@ -12,7 +12,7 @@ export default function RadioLabelText(RadioLabelTextProps) {
     <div key={fontIndex}>
       {font.categories.map((categories, categoriesIndex) => {
         return (<div key={categoriesIndex}>
-          {font.categories[categoriesIndex].category.filter(item => isGraphiteAssumed ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((category, categoryIndex) => {
+          {font.categories[categoriesIndex].category.filter(item => isGraphite ? item.opentype_render_required !== true : item.graphite_render_required !== true).map((category, categoryIndex) => {
             return (<div key={categoryIndex}>
               {category.sets.map((sets, setsIndex) => {
                 return (<div key={setsIndex}>
@@ -29,14 +29,14 @@ export default function RadioLabelText(RadioLabelTextProps) {
       </div>)
       })}
     </div>
-  )), [isGraphiteAssumed, ffsArr]);
+  )), [isGraphite, ffsArr]);
 
   return labelJsxText;
 }
 
 RadioLabelText.propTypes = {
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
   /** Array of Font Feature Settings Options */
   ffsArr: PropTypes.array.isRequired,
 };

--- a/src/components/helpers/UsePrevious.jsx
+++ b/src/components/helpers/UsePrevious.jsx
@@ -10,8 +10,8 @@ export default function UsePrevious(value) {
 }
 
 UsePrevious.propTypes = {
-  /** Is Graphite Assumed? */
-  isGraphiteAssumed: PropTypes.bool.isRequired,
+  /** Is Rendering in Graphite? */
+  isGraphite: PropTypes.bool.isRequired,
   /** Array of Font Feature Settings Options */
   ffsArr: PropTypes.array.isRequired,
 };


### PR DESCRIPTION
### This PR is for use in conjunction with or before the planned Electronite version of Liminal.
- Instead detecting the presence of Firefox, this upgrade detects when Graphite rendering exists, whatever the client.

### Important: Please accept "Change to Graphite detection." PRs on the following repos at the same time:
- core-client-settings
- core-client-workspace 
- core-client-content
- core-client-i18n-editor 
- webfonts-core: _Contains new font classes in support of the changes above._
- pankosmia-web: _keeping 1 version of font "truth" until such time as they are no longer included here_
- pithekos: _keeping: 1 version of font "truth" until such time as they are no longer included here_

### New in this repo (delete ~/pankomsia_working before server start):
- Firefox with Graphite disabled displays less-robust Noto Nastaliq Urdu in place of Awami, with a message on enabling Graphite added to (i).
- Any client without Graphite using Padauk get: (i) "Additional features available under Graphite."

### Changes to process flow in this repo:
- GraphiteTest(): Confirm the testFont has loaded, then useDetectRender
- If there is no Graphite then font_set is re-shaped to avoid bonked Awami.
- If Graphite is running then font_set is applied directly.