### PR TITLE
update graphite support info

### DIFF
--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -107,7 +107,7 @@
       "id": "Pengaturan Pabrik"
     },
     "best_with": {
-      "en": "Best viewed with Graphite.",
+      "en": "Best with Graphite.",
       "fr": "Mieux vu avec Graphite.",
       "id": "Terbaik dengan Graphite."
     },
@@ -117,14 +117,14 @@
       "id": "Fitur tambahan tersedia di bawah Graphite."
     },
     "graphite_support": {
-      "en": "Firefox and Electronite support Graphite.",
-      "fr": "Firefox et Electronite prennent en charge Graphite.",
-      "id": "Firefox dan Electronite mendukung Graphite."
+      "en": "Firefox, Zen Browser, LibreWolf and Electronite support Graphite.",
+      "fr": "Firefox, Zen Browser, LibreWolf et Electronite prennent en charge Graphite.",
+      "id": "Firefox, Zen Browser, LibreWolf dan Electronite mendukung Graphite."
     },
     "graphite_is_off": {
-      "en": "Set gfx.font_rendering.graphite.enabled to true in about:config to enable Graphite in Firefox.",
-      "id": "Atur gfx.font_rendering.graphite.enabled menjadi true di about:config untuk mengaktifkan Graphite di Firefox.",
-      "fr": "Définissez gfx.font_rendering.graphite.enabled sur true dans about:config pour activer Graphite dans Firefox."
+      "en": "Set gfx.font_rendering.graphite.enabled to true in about:config in your browser to enable Graphite.",
+      "id": "Atur gfx.font_rendering.graphite.enabled menjadi true dalam about:config di peramban web untuk mengaktifkan Graphite.",
+      "fr": "Définissez gfx.font_rendering.graphite.enabled sur true dans about:config de votre navigateur Web pour activer Graphite."
     }
   }
 }

--- a/src/components/BlendedFontArabicUrduSelection.jsx
+++ b/src/components/BlendedFontArabicUrduSelection.jsx
@@ -204,7 +204,7 @@ export default function BlendedFontArabicUrduSelection(blendedFontArabicUrduSele
                 }
               </Tooltip>
             }
-            {isAwami && !isGraphite && <div className={adjSelectedFontClass} style={{margin: 'auto 0',fontSize: '100%' }}>{doI18n("pages:core-settings:best_with", i18nRef.current)} {isFirefox ? doI18n("pages:core-settings:graphite_is_off", i18nRef.current) : doI18n("pages:core-settings:graphite_support", i18nRef.current)}</div>}
+            {isAwami && !isGraphite && <div className={adjSelectedFontClass} style={{margin: 'auto 0',fontSize: '100%' }}>{doI18n("pages:core-settings:best_with", i18nRef.current)} {isFirefox && doI18n("pages:core-settings:graphite_is_off", i18nRef.current)}</div>}
             {showArabicUrduFeatures && <FontFeaturesArabicUrdu {...fontFeaturesArabicUrduProps} />}
           </Stack>
         </div>

--- a/src/components/BlendedFontsPage.jsx
+++ b/src/components/BlendedFontsPage.jsx
@@ -647,7 +647,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
                             }
                           </Tooltip>
                         }
-                        {isAwami && !isGraphite && <div className={adjSelectedFontClass} style={{margin: 'auto 0',fontSize: '100%' }}>{doI18n("pages:core-settings:best_with", i18nRef.current)} {isFirefox ? doI18n("pages:core-settings:graphite_is_off", i18nRef.current) : doI18n("pages:core-settings:graphite_support", i18nRef.current)}</div>}
+                        {isAwami && !isGraphite && <div className={adjSelectedFontClass} style={{margin: 'auto 0',fontSize: '100%' }}>{doI18n("pages:core-settings:best_with", i18nRef.current)} {isFirefox && doI18n("pages:core-settings:graphite_is_off", i18nRef.current)}</div>}
                       </div>
                       <div style={{ display: 'flex', flexDirection: 'row' }}>
                         <FormControl fullWidth style={{maxWidth: 400, minWidth: 400}} size="small">


### PR DESCRIPTION
This implements the following on both the blended fonts page and advanced settings.

1. Reduce the onscreen rendered text when Graphite is not available to just this (removing the list of what supports graphite as it is included in the (i) mouseover):
![image](https://github.com/user-attachments/assets/fb398153-5601-4672-8f3a-332b32dbbbec)

2. Unless the the browser identifies as Firefox and the Graphite is turned off. Zen Browser and LibreWolfe both identify as Firefox and have the same setting, so this works with them too.
![image](https://github.com/user-attachments/assets/ba78b732-19e1-4ab9-a7dc-66745f4e536d)

3. Update the (i) mouseovers to include Zen Browser and LibreWolfe:

- Awami Nastaliq is set and Graphite is active:
![image](https://github.com/user-attachments/assets/0433692c-92e2-4d99-834d-a9340bb18078)

- Awami Nastaliq is set and Graphite is **not** active:
![image](https://github.com/user-attachments/assets/695bc577-e7b7-4d8b-96fb-8f79dc234dd6)

- Padauk is set and Graphite is **not** active:
![image](https://github.com/user-attachments/assets/8978e3ce-6e79-4bc8-b699-9ae16e39bf93)
