### PR TITLE
Padauk 6.000 and Awami Nastaliq 3.400 changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/icons-material": "^6.1.5",
         "@mui/material": "^6.1.5",
         "dompurify": "^3.2.4",
-        "font-detect-rhl": "^1.1.8",
+        "font-detect-rhl": "1.1.9",
         "pankosmia-rcl": "^0.1.37",
         "pithekos-lib": "^0.11.20",
         "prop-types": "^15.8.1",
@@ -5583,9 +5583,9 @@
       "peer": true
     },
     "node_modules/font-detect-rhl": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/font-detect-rhl/-/font-detect-rhl-1.1.8.tgz",
-      "integrity": "sha512-jhJWOpyFo+hPx0zrJZ1j3oiebZqO38Wf3Oq0RkUxg9DEAcw8qXJq2Lx/R+PnZGDlLhT8yLPfGswT6qjhxhdOsg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/font-detect-rhl/-/font-detect-rhl-1.1.9.tgz",
+      "integrity": "sha512-IwDy3x70H46tP8o9hNel2LmfMhfJshviIekjTyLl+dmpr7AUqQc8FdPa+cWOQFp3sbeADqolUzLjhlilvz6Dag==",
       "dependencies": {
         "prop-types": "^15.6.1",
         "use-deep-compare": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@mui/icons-material": "^6.1.5",
     "@mui/material": "^6.1.5",
     "dompurify": "^3.2.4",
-    "font-detect-rhl": "^1.1.8",
+    "font-detect-rhl": "1.1.9",
     "pankosmia-rcl": "^0.1.37",
     "pithekos-lib": "^0.11.20",
     "prop-types": "^15.8.1",

--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -88,9 +88,9 @@
       "grc": "Ἀραϐικὰ γράμματα"
     },
     "replace_awami": {
-      "en": "Noto Nastaliq Urdu if not rendered on Graphite.",
-      "fr": "Noto Nastaliq Urdu si non rendu sur Graphite.",
-      "id": "Noto Nastaliq Urdu jika tidak ditampilkan atas Graphite."
+      "en": "Replaced with Noto Nastaliq Urdu if Graphite is not available.",
+      "fr": "Remplacé par Noto Nastaliq Urdu si Graphite non est diponible.",
+      "id": "Diganti dengan Noto Nastaliq Urdu jika Graphite tidak tersedia."
     },
     "replace_noto": {
       "en": "Replaced with Awami Nastaliq when Graphite is available.",

--- a/src/components/BlendedFontArabicUrduSelection.jsx
+++ b/src/components/BlendedFontArabicUrduSelection.jsx
@@ -262,7 +262,23 @@ export default function BlendedFontArabicUrduSelection(
             </FormControl>
             {!isArabicUrduDefault && (
               <Tooltip
-                title={`Awami Nastaliq (${doI18n("pages:core-settings:replace_awami", i18nRef.current)})`}
+                title={[
+                  "Awami Nastaliq",
+                  !isGraphite && " -- ",
+                  !isGraphite &&
+                    doI18n(
+                      "pages:core-settings:replace_awami",
+                      i18nRef.current,
+                    ),
+                  !isGraphite &&
+                    isFirefox &&
+                    doI18n(
+                      "pages:core-settings:graphite_is_off",
+                      i18nRef.current,
+                    ),
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
                 placement="right"
                 arrow
               >
@@ -274,29 +290,18 @@ export default function BlendedFontArabicUrduSelection(
                 />
               </Tooltip>
             )}
-            {isAwami && (
+            {isAwami && !isGraphite && (
               <Tooltip
-                title={
-                  (isGraphite
-                    ? doI18n(
-                        "pages:core-settings:replace_awami",
-                        i18nRef.current,
-                      )
-                    : doI18n(
-                        "pages:core-settings:replace_noto",
-                        i18nRef.current,
-                      )) +
-                  " " +
-                  (!isGraphite && isFirefox
-                    ? doI18n(
-                        "pages:core-settings:graphite_is_off",
-                        i18nRef.current,
-                      )
-                    : doI18n(
-                        "pages:core-settings:graphite_support",
-                        i18nRef.current,
-                      ))
-                }
+                title={[
+                  doI18n("pages:core-settings:replace_noto", i18nRef.current),
+                  !isFirefox &&
+                    doI18n(
+                      "pages:core-settings:graphite_support",
+                      i18nRef.current,
+                    ),
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
                 placement="right"
               >
                 {isGraphite ? (

--- a/src/components/BlendedFontMyanmarSelection.jsx
+++ b/src/components/BlendedFontMyanmarSelection.jsx
@@ -244,29 +244,6 @@ export default function BlendedFontMyanmarSelection(
                 />
               </Tooltip>
             )}
-            {!isGraphite && isPadauk && (
-              <Tooltip
-                title={
-                  doI18n("pages:core-settings:padauk_tip", i18nRef.current) +
-                  " " +
-                  (isFirefox
-                    ? doI18n(
-                        "pages:core-settings:graphite_is_off",
-                        i18nRef.current,
-                      )
-                    : doI18n(
-                        "pages:core-settings:graphite_support",
-                        i18nRef.current,
-                      ))
-                }
-                placement="right"
-              >
-                <InfoIcon
-                  color="secondary"
-                  style={{ paddingLeft: "9px", margin: "auto 0" }}
-                />
-              </Tooltip>
-            )}
             {showMyanmarFeatures && (
               <FontFeaturesMyanmar {...fontFeaturesMyanmarProps} />
             )}

--- a/src/components/BlendedFontsPage.jsx
+++ b/src/components/BlendedFontsPage.jsx
@@ -223,7 +223,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
       setWebFontsArabicUrdu([
         {
           display_name: isGraphite
-            ? "Awami Nastaliq 3.300"
+            ? "Awami Nastaliq 3.400"
             : "Noto Nastaliq Urdu 4.000",
           id: "Pankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrdu",
           name: "Pankosmia-Awami Nastaliq",
@@ -241,7 +241,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
         },
         {
           display_name: isGraphite
-            ? "Awami Nastaliq Medium 3.300"
+            ? "Awami Nastaliq Medium 3.400"
             : "Noto Nastaliq Urdu 4.000",
           id: "Pankosmia-AwamiNastaliqMediumPankosmia-NotoNastaliqUrdu",
           name: "Pankosmia-Awami Nastaliq Medium",
@@ -253,7 +253,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
         },
         {
           display_name: isGraphite
-            ? "Awami Nastaliq Semi Bold 3.300"
+            ? "Awami Nastaliq Semi Bold 3.400"
             : "Noto Nastaliq Urdu 4.000",
           id: "Pankosmia-AwamiNastaliqSemiBoldPankosmia-NotoNastaliqUrdu",
           name: "Pankosmia-Awami Nastaliq Semi Bold",
@@ -265,7 +265,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
         },
         {
           display_name: isGraphite
-            ? "Awami Nastaliq Extra Bold 3.300"
+            ? "Awami Nastaliq Extra Bold 3.400"
             : "Noto Nastaliq Urdu 4.000",
           id: "Pankosmia-AwamiNastaliqExtraBoldPankosmia-NotoNastaliqUrdu",
           name: "Pankosmia-Awami Nastaliq Extra Bold",
@@ -772,7 +772,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
       "Pankosmia-AwamiNastaliqPankosmia-NotoNastaliqUrdu",
     );
     // setArabicUrduFfsId('Awami Nastaliq');
-    setArabicUrduFontDisplayName("Awami Nastaliq 3.300");
+    setArabicUrduFontDisplayName("Awami Nastaliq 3.400");
     setArabicUrduFontName("Pankosmia-Awami Nastaliq");
   };
 

--- a/src/components/BlendedFontsPage.jsx
+++ b/src/components/BlendedFontsPage.jsx
@@ -178,7 +178,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
     ) {
       setWebFontsMyanmar([
         {
-          display_name: "Padauk 5.100",
+          display_name: "Padauk 6.000",
           id: "Pankosmia-Padauk",
           name: "Pankosmia-Padauk",
           settings_id: "Padauk",
@@ -186,11 +186,33 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
           example: "ဥပမာ",
         },
         {
-          display_name: "Padauk Book 5.100",
-          id: "Pankosmia-PadaukBook",
-          name: "Pankosmia-Padauk Book",
+          display_name: "Padauk Medium 6.000",
+          id: "Pankosmia-PadaukMedium",
+          name: "Pankosmia-Padauk Medium",
           settings_id: "Padauk",
-          shortlist: true,
+          shortlist:
+            selectedMyanmarFontClassSubstr.toString() ===
+            "Pankosmia-PadaukMedium",
+          example: "ဥပမာ",
+        },
+        {
+          display_name: "Padauk Semi Bold 6.000",
+          id: "Pankosmia-PadaukSemiBold",
+          name: "Pankosmia-Padauk Semi Bold",
+          settings_id: "Padauk",
+          shortlist:
+            selectedMyanmarFontClassSubstr.toString() ===
+            "Pankosmia-PadaukSemiBold",
+          example: "ဥပမာ",
+        },
+        {
+          display_name: "Padauk Extra Bold 6.000",
+          id: "Pankosmia-PadaukExtraBold",
+          name: "Pankosmia-Padauk Extra Bold",
+          settings_id: "Padauk",
+          shortlist:
+            selectedMyanmarFontClassSubstr.toString() ===
+            "Pankosmia-PadaukExtraBold",
           example: "ဥပမာ",
         },
         {
@@ -779,7 +801,7 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
   const handleClickMyanmar = () => {
     setSelectedMyanmarFontClassSubstr("Pankosmia-Padauk");
     setMyanmarFfsId("Padauk");
-    setMyanmarFontDisplayName("Padauk 5.100");
+    setMyanmarFontDisplayName("Padauk 6.000");
     setMyanmarFontName("Pankosmia-Padauk");
   };
 
@@ -1130,7 +1152,23 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
                         </FormControl>
                         {!isArabicUrduDefault && (
                           <Tooltip
-                            title={`Awami Nastaliq (${doI18n("pages:core-settings:replace_awami", i18nRef.current)})`}
+                            title={[
+                              "Awami Nastaliq",
+                              !isGraphite && " -- ",
+                              !isGraphite &&
+                                doI18n(
+                                  "pages:core-settings:replace_awami",
+                                  i18nRef.current,
+                                ),
+                              !isGraphite &&
+                                isFirefox &&
+                                doI18n(
+                                  "pages:core-settings:graphite_is_off",
+                                  i18nRef.current,
+                                ),
+                            ]
+                              .filter(Boolean)
+                              .join(" ")}
                             placement="right"
                             arrow
                           >
@@ -1148,29 +1186,21 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
                           style={{ paddingLeft: "9px", margin: "auto 0" }}
                           onClick={handleClickArabicUrduMore}
                         />
-                        {isAwami && (
+                        {isAwami && !isGraphite && (
                           <Tooltip
-                            title={
-                              (isGraphite
-                                ? doI18n(
-                                    "pages:core-settings:replace_awami",
-                                    i18nRef.current,
-                                  )
-                                : doI18n(
-                                    "pages:core-settings:replace_noto",
-                                    i18nRef.current,
-                                  )) +
-                              " " +
-                              (!isGraphite && isFirefox
-                                ? doI18n(
-                                    "pages:core-settings:graphite_is_off",
-                                    i18nRef.current,
-                                  )
-                                : doI18n(
-                                    "pages:core-settings:graphite_support",
-                                    i18nRef.current,
-                                  ))
-                            }
+                            title={[
+                              doI18n(
+                                "pages:core-settings:replace_noto",
+                                i18nRef.current,
+                              ),
+                              !isFirefox &&
+                                doI18n(
+                                  "pages:core-settings:graphite_support",
+                                  i18nRef.current,
+                                ),
+                            ]
+                              .filter(Boolean)
+                              .join(" ")}
                             placement="right"
                           >
                             {isGraphite ? (
@@ -1258,32 +1288,6 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
                           style={{ paddingLeft: "9px", margin: "auto 0" }}
                           onClick={handleClickMyanmarMore}
                         />
-                        {!isGraphite && isPadauk && (
-                          <Tooltip
-                            title={
-                              doI18n(
-                                "pages:core-settings:padauk_tip",
-                                i18nRef.current,
-                              ) +
-                              " " +
-                              (isFirefox
-                                ? doI18n(
-                                    "pages:core-settings:graphite_is_off",
-                                    i18nRef.current,
-                                  )
-                                : doI18n(
-                                    "pages:core-settings:graphite_support",
-                                    i18nRef.current,
-                                  ))
-                            }
-                            placement="right"
-                          >
-                            <InfoIcon
-                              color="secondary"
-                              style={{ paddingLeft: "9px", margin: "auto 0" }}
-                            />
-                          </Tooltip>
-                        )}
                       </div>
                       <div
                         className={adjSelectedFontClass}
@@ -1322,8 +1326,13 @@ export default function BlendedFontsPage(blendedFontsPageProps) {
                                   "pages:core-settings:select_arabicurduscript",
                                   i18nRef.current,
                                 )}
-                                :{" "}
-                                {`Awami Nastaliq (${doI18n("pages:core-settings:replace_awami", i18nRef.current)})`}
+                                : Awami Nastaliq{" "}
+                                {!isGraphite &&
+                                  " -- " +
+                                    doI18n(
+                                      "pages:core-settings:replace_awami",
+                                      i18nRef.current,
+                                    )}
                                 <br />
                                 <br />
                                 {doI18n(

--- a/src/components/data/awamiFfsLessPuncAndSpacing.json
+++ b/src/components/data/awamiFfsLessPuncAndSpacing.json
@@ -138,6 +138,27 @@
               {
                 "set": [
                   {
+                    "title": "High Hamza",
+                    "name": "hihm",
+                    "id": "hihm-label",
+                    "default": "0",
+                    "label": "ٴ",
+                    "options": [
+                      {
+                        "tip": "Urdu style",
+                        "value": "0"
+                      },
+                      {
+                        "tip": "Malay style",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "set": [
+                  {
                     "title": "Collision avoidance",
                     "name": "agca",
                     "id": "collision-avoidance-label",


### PR DESCRIPTION
# 1 of 3 Integrated PR's
This PR is to be reviewed and merged in conjunction with its corresponding webfonts-core and resource-core PR's.

## Summary of changes:
- Bumped font-detect-rhl / updated font-features settings for Awami and Padauk
- Removed Padauk Book from setting drop-downs as it went away in the font upgrade
- Added Padauk Medium, Padauk Semi Bold, and Padauk Extra Bold to the advanced Padauk dropdown
- When Graphite is active:
    - the settings information tip is now removed that use to mention Noto Nashk Nastaliq replacement when not Graphite and listed several browsers that support Graphite.
    - the factory settings reset links no longer mention Noto Nashk Nastaliq replacement when not Graphite
- When Graphite is _not_ active:
    - the Padauk tooltip is removed as the latest version removed the Graphite extras and made it all OpenType

## Caution and Consideration:
- this PR needs [this resource-core PR](https://github.com/pankosmia/resource-core/pull/26) and this [webfonts-core PR](https://github.com/pankosmia/webfonts-core/pull/3)
    - However, dev and main and qa all use the same resource-core and webfonts-core branch.  So we will break some things on qa and main when those PR's are merged, until this PR is moved on up to qa and main.
- this PR will require users to delete user_settings.json on install, which under current behavior also requires deletion of `~/pankomia/[short_app_name]` and all of its contents, otherwise everything does not get put back
  - our script that deletes on install currently only deletes `i18n.json`, `webfonts` and `temp`. 