### PR TITLE
New credits section for "about" view

### DIFF
--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -147,7 +147,7 @@
     },
     "about_server": {
       "en": "About",
-      "fr": "A propos"
+      "fr": "A propos de "
     },
     "update": {
       "en": "Updates"
@@ -165,6 +165,16 @@
     "tooltip_languages": {
       "en": "Complete, fallback languages will not be used",
       "fr": "Complète, les langues suivantes ne seront pas utilisées"
+    },
+    "text_git": {
+      "en": "Thanks to Jason Long for the  <a href='https://git-scm.com/community/logos'> {Git Logo} </a>, licensed under the <a href=' https://creativecommons.org/licenses/by/3.0/'> {Creative Commons Attribution 3.0 Unported License} </a>.<br/>The logo was inverted (background removed and logo filled)."
+    },
+    "git_logo": {
+      "en": "Git logo",
+      "fr": "Logo Git"
+    },
+    "license_creative_commons": {
+      "en": "Creative Commons Attribution 3.O Unported License"
     }
   }
 }

--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -167,14 +167,16 @@
       "fr": "Complète, les langues suivantes ne seront pas utilisées"
     },
     "text_git": {
-      "en": "Thanks to Jason Long for the  <a href='https://git-scm.com/community/logos'> {Git Logo} </a>, licensed under the <a href=' https://creativecommons.org/licenses/by/3.0/'> {Creative Commons Attribution 3.0 Unported License} </a>.<br/>The logo was inverted (background removed and logo filled)."
+      "en": "Thanks to Jason Long for the  <a href='https://git-scm.com/community/logos'> {Git Logo} </a>, licensed under the <a href=' https://creativecommons.org/licenses/by/3.0/'> {Creative Commons Attribution 3.0 Unported License} </a>.<br/>The logo was inverted (background removed and logo filled).",
+      "fr": "Merci à Jason Long pour le <a href='https://git-scm.com/community/logos'>  {Logo Git} </a>, sous <a href=' https://creativecommons.org/licenses/by/3.0/'> {licence Creative Commons Attribution 3.0 non transposé}.</a>.<br/>Le logo a été inversé (arrière-plan supprimé et logo rempli)."
     },
     "git_logo": {
       "en": "Git logo",
       "fr": "Logo Git"
     },
     "license_creative_commons": {
-      "en": "Creative Commons Attribution 3.O Unported License"
+      "en": "Creative Commons Attribution 3.O Unported License",
+      "fr": "licence Creative Commons Attribution 3.0 non transposé"
     },
     "credit": {
       "en": "Credits",

--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -175,6 +175,10 @@
     },
     "license_creative_commons": {
       "en": "Creative Commons Attribution 3.O Unported License"
+    },
+    "credit": {
+      "en": "Credits",
+      "fr": "Crédits"
     }
   }
 }

--- a/src/components/AboutViewServer.jsx
+++ b/src/components/AboutViewServer.jsx
@@ -1,11 +1,10 @@
 import { useContext } from "react";
-import { Box, Grid2, Typography } from "@mui/material";
+import { Box, Button, Grid2, Typography } from "@mui/material";
 import { doI18n } from "pithekos-lib";
 import { i18nContext } from "pankosmia-rcl";
 
 export default function AboutViewServer({ dataServer }) {
   const { i18nRef } = useContext(i18nContext);
-
   return (
     <Grid2 container spacing={1.5}>
       <Grid2 size={12}>
@@ -27,6 +26,26 @@ export default function AboutViewServer({ dataServer }) {
             </Box>
           ) : null}
         </Typography>
+      </Grid2>
+      <Grid2 size={12}>
+        <Typography variant="h6" sx={{ fontWeight: "bold", mb: 1 }}>
+          {doI18n("pages:core-settings:credit", i18nRef.current)}
+        </Typography>
+        <Typography
+          fullWidth
+          size="small"
+          dangerouslySetInnerHTML={{
+            __html: doI18n("pages:core-settings:text_git", i18nRef.current)
+              .replace(
+                "{Git Logo}",
+                `${doI18n("pages:core-settings:git_logo", i18nRef.current)}`,
+              )
+              .replace(
+                "{Creative Commons Attribution 3.0 Unported License}",
+                `${doI18n("pages:core-settings:license_creative_commons", i18nRef.current)}`,
+              ),
+          }}
+        />
       </Grid2>
     </Grid2>
   );


### PR DESCRIPTION
This pull request adds a credits section to the server "About" view, providing attribution for the Git logo and its license, and updates localization strings to support this new section. The main changes include updates to both the UI and the translation metadata.

**User Interface Enhancements:**

* Added a "Credits" section to the `AboutViewServer` component, displaying translated attribution for the Git logo and its license using localized strings and safe HTML rendering.

**Localization and Metadata Updates:**

* Added new translation keys and values for the credits section, Git logo attribution, and license information in both English and French to `pankosmia_metadata.json`.
* Updated the French translation for the "About" label for improved clarity.