### PR TITLE
System plugins tab -> Firefox and FFmpeg download tab

### DIFF
--- a/pankosmia_metadata.json
+++ b/pankosmia_metadata.json
@@ -182,6 +182,66 @@
     "credit": {
       "en": "Credits",
       "fr": "Crédits"
+    },
+    "system_plugins": {
+      "en": "System Plugins",
+      "fr": "Plugins système"
+    },
+    "system_plugins_intro": {
+      "en": "Some functionalities rely on external utilities you need to install to use.",
+      "fr": "Certaines fonctionnalités reposent sur des utilitaires externes que vous devez installer pour les utiliser."
+    },
+    "ffmpeg_title": {
+      "en": "FFmpeg for audio",
+      "fr": "FFmpeg pour l'audio"
+    },
+    "ffmpeg_desc": {
+      "en": "FFmpeg is a multimedia framework. It is used for the audio editor, to generate final audio files or to export Open Bible Stories videos.",
+      "fr": "FFmpeg est un framework multimédia. Il est utilisé pour l'éditeur audio, pour générer les fichiers audio finaux ou pour exporter les vidéos Open Bible Stories."
+    },
+    "pdf_engine_title": {
+      "en": "Render engine for PDF",
+      "fr": "Moteur de rendu pour PDF"
+    },
+    "pdf_engine_desc": {
+      "en": "This render engine is used to generate large PDFs with complex fonts.",
+      "fr": "Ce moteur de rendu est utilisé pour générer de grands PDF avec des polices complexes."
+    },
+    "download": {
+      "en": "Download",
+      "fr": "Télécharger"
+    },
+    "download_unavailable": {
+      "en": "Unavailable",
+      "fr": "Indisponible"
+    },
+    "download_unavailable_tip": {
+      "en": "Unavailable in web browser",
+      "fr": "Indisponible dans le navigateur web"
+    },
+    "download_checking": {
+      "en": "Checking…",
+      "fr": "Vérification…"
+    },
+    "download_downloading": {
+      "en": "Downloading…",
+      "fr": "Téléchargement…"
+    },
+    "download_installed": {
+      "en": "Installed",
+      "fr": "Installé"
+    },
+    "download_retry": {
+      "en": "Retry Download",
+      "fr": "Réessayer le téléchargement"
+    },
+    "download_percent_complete": {
+      "en": "complete",
+      "fr": "terminé"
+    },
+    "download_failed": {
+      "en": "Download failed",
+      "fr": "Échec du téléchargement"
     }
   }
 }

--- a/src/components/AssetDownloadButton.jsx
+++ b/src/components/AssetDownloadButton.jsx
@@ -1,10 +1,13 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
 import { Button, LinearProgress, Typography, Stack } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckOutlined";
 import ErrorIcon from "@mui/icons-material/ErrorOutlined";
 import DownloadIcon from "@mui/icons-material/SaveAltOutlined";
+import { i18nContext } from "pankosmia-rcl";
+import { doI18n } from "pankosmia-lib/i18n";
 
 export default function AssetDownloadButton({ asset }) {
+  const { i18nRef } = useContext(i18nContext);
   const [installed, setInstalled] = useState(false);
   const [status, setStatus] = useState("checking"); // checking | idle | downloading | complete | error | unavailable
   const [progress, setProgress] = useState(null);
@@ -163,14 +166,29 @@ export default function AssetDownloadButton({ asset }) {
                 ? "error"
                 : "primary"
           }
-          title={!isElectron ? "Unavailable in web browser" : "Download"}
+          title={
+            !isElectron
+              ? doI18n(
+                  "pages:core-settings:download_unavailable_tip",
+                  i18nRef.current,
+                )
+              : doI18n("pages:core-settings:download", i18nRef.current)
+          }
         >
-          {status === "checking" && !isElectron && "Unavailable"}
-          {status === "checking" && isElectron && "Checking…"}
-          {status === "idle" && "Download"}
-          {status === "downloading" && "Downloading…"}
-          {status === "complete" && "Installed"}
-          {status === "error" && "Retry Download"}
+          {status === "checking" &&
+            !isElectron &&
+            doI18n("pages:core-settings:download_unavailable", i18nRef.current)}
+          {status === "checking" &&
+            isElectron &&
+            doI18n("pages:core-settings:download_checking", i18nRef.current)}
+          {status === "idle" &&
+            doI18n("pages:core-settings:download", i18nRef.current)}
+          {status === "downloading" &&
+            doI18n("pages:core-settings:download_downloading", i18nRef.current)}
+          {status === "complete" &&
+            doI18n("pages:core-settings:download_installed", i18nRef.current)}
+          {status === "error" &&
+            doI18n("pages:core-settings:download_retry", i18nRef.current)}
         </Button>
 
         {status === "downloading" && (
@@ -181,15 +199,19 @@ export default function AssetDownloadButton({ asset }) {
             />
             <Typography variant="body2" color="text.secondary">
               {hasProgress
-                ? `${Math.round(progress)}% complete`
-                : "Downloading…"}
+                ? `${Math.round(progress)}% ${doI18n("pages:core-settings:download_percent_complete", i18nRef.current)}`
+                : doI18n(
+                    "pages:core-settings:download_downloading",
+                    i18nRef.current,
+                  )}
             </Typography>
           </>
         )}
 
         {status === "error" && (
           <Typography variant="body2" color="error">
-            Download failed{errorMessage ? `: ${errorMessage}` : ""}.
+            {doI18n("pages:core-settings:download_failed", i18nRef.current)}
+            {errorMessage ? `: ${errorMessage}` : ""}.
           </Typography>
         )}
       </Stack>

--- a/src/components/AssetDownloadButton.jsx
+++ b/src/components/AssetDownloadButton.jsx
@@ -1,0 +1,198 @@
+import { useState, useEffect } from "react";
+import { Button, LinearProgress, Typography, Stack } from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckOutlined";
+import ErrorIcon from "@mui/icons-material/ErrorOutlined";
+import DownloadIcon from "@mui/icons-material/SaveAltOutlined";
+
+export default function AssetDownloadButton({ asset }) {
+  const [installed, setInstalled] = useState(false);
+  const [status, setStatus] = useState("checking"); // checking | idle | downloading | complete | error | unavailable
+  const [progress, setProgress] = useState(null);
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [isElectron, setIsElectron] = useState(false);
+
+  useEffect(() => {
+    if (!window.electronAPI) {
+      setIsElectron(false);
+      return;
+    } else {
+      setIsElectron(true);
+    }
+
+    let cancelled = false;
+
+    switch (asset) {
+      case "ffmpeg":
+        window.electronAPI.checkFfmpegInstalled().then((installed) => {
+          if (!cancelled) {
+            setInstalled(installed);
+            setStatus(installed ? "complete" : "idle");
+          }
+        });
+        break;
+      case "firefox":
+        window.electronAPI.checkFirefoxInstalled().then((installed) => {
+          if (!cancelled) {
+            setInstalled(installed);
+            setStatus(installed ? "complete" : "idle");
+          }
+        });
+        break;
+      default:
+        return;
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [setInstalled, asset]);
+
+  useEffect(() => {
+    if (!window.electronAPI) {
+      return;
+    }
+
+    switch (asset) {
+      case "ffmpeg":
+        const removeProgressFfmpeg =
+          window.electronAPI.onFfmpegDownloadProgress((percent) => {
+            if (typeof percent === "number" && !Number.isNaN(percent)) {
+              setProgress(Math.max(0, Math.min(100, percent)));
+            }
+          });
+
+        const removeCompleteFfmpeg =
+          window.electronAPI.onFfmpegDownloadComplete(
+            (success, errorMessage) => {
+              setStatus(success ? "complete" : "error");
+              setInstalled(!!success);
+
+              if (success) {
+                setProgress(100);
+                setErrorMessage(null);
+              } else {
+                setErrorMessage(errorMessage || null);
+              }
+            },
+          );
+
+        return () => {
+          removeProgressFfmpeg();
+          removeCompleteFfmpeg();
+        };
+        break;
+      case "firefox":
+        const removeProgressFirefox = window.electronAPI.onDownloadProgress(
+          (percent, downloadedBytes, totalBytes) => {
+            console.log(
+              "onDownloadProgress",
+              percent,
+              downloadedBytes,
+              totalBytes,
+            );
+            if (typeof percent === "number" && !Number.isNaN(percent)) {
+              setProgress(Math.max(0, Math.min(100, percent)));
+            }
+          },
+        );
+        const removeCompleteFirefox = window.electronAPI.onDownloadComplete(
+          (success, errorMessage) => {
+            setStatus(success ? "complete" : "error");
+            setInstalled(!!success);
+          },
+        );
+        return () => {
+          removeProgressFirefox();
+          removeCompleteFirefox();
+        };
+        break;
+      default:
+        console.error("Invalid asset", asset);
+        return;
+    }
+  }, [setInstalled, asset]);
+
+  const handleInstall = () => {
+    if (!window.electronAPI || !asset) {
+      return;
+    }
+    setStatus("downloading");
+    setProgress(null);
+    setErrorMessage(null);
+
+    switch (asset) {
+      case "ffmpeg":
+        window.electronAPI.downloadFfmpeg();
+        break;
+      case "firefox":
+        window.electronAPI.downloadFirefox();
+        break;
+      default:
+        console.error("Invalid asset", asset);
+        return;
+    }
+  };
+
+  const hasProgress = typeof progress === "number";
+
+  return (
+    <>
+      <Stack sx={{ maxWidth: 200 }}>
+        <Button
+          variant="contained"
+          startIcon={
+            status === "complete" ? (
+              <CheckCircleIcon />
+            ) : status === "error" ? (
+              <ErrorIcon />
+            ) : (
+              <DownloadIcon />
+            )
+          }
+          onClick={() => handleInstall(asset)}
+          disabled={
+            status === "checking" ||
+            status === "downloading" ||
+            status === "complete" ||
+            !isElectron
+          }
+          color={
+            status === "complete"
+              ? "success"
+              : status === "error"
+                ? "error"
+                : "primary"
+          }
+          title={!isElectron ? "Unavailable in web browser" : "Download"}
+        >
+          {status === "checking" && !isElectron && "Unavailable"}
+          {status === "checking" && isElectron && "Checking…"}
+          {status === "idle" && "Download"}
+          {status === "downloading" && "Downloading…"}
+          {status === "complete" && "Installed"}
+          {status === "error" && "Retry Download"}
+        </Button>
+
+        {status === "downloading" && (
+          <>
+            <LinearProgress
+              variant={hasProgress ? "determinate" : "indeterminate"}
+              value={hasProgress ? progress : undefined}
+            />
+            <Typography variant="body2" color="text.secondary">
+              {hasProgress
+                ? `${Math.round(progress)}% complete`
+                : "Downloading…"}
+            </Typography>
+          </>
+        )}
+
+        {status === "error" && (
+          <Typography variant="body2" color="error">
+            Download failed{errorMessage ? `: ${errorMessage}` : ""}.
+          </Typography>
+        )}
+      </Stack>
+    </>
+  );
+}

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -9,6 +9,7 @@ import BlendedFontsPage from "./BlendedFontsPage";
 import LanguageSelection from "./LanguageSelection";
 import GraphiteTest from "./GraphiteTest";
 import AboutViewServer from "./AboutViewServer";
+import SystemPluginPage from "./SystemPluginPage";
 
 const CustomTabPanel = (props) => {
   const { children, value, index, ...other } = props;
@@ -143,6 +144,12 @@ export default function Settings() {
             {...a11yProps(1)}
           />
           <Tab
+            label={doI18n(
+              "pages:core-settings:system_plugins",
+              i18nRef.current,
+            )}
+          />
+          <Tab
             label={`${doI18n("pages:core-settings:about_server", i18nRef.current)} ${nameServer || null}`}
           />
         </Tabs>
@@ -158,6 +165,9 @@ export default function Settings() {
         <BlendedFontsPage {...blendedFontsPageProps} />
       </CustomTabPanel>
       <CustomTabPanel value={value} index={2}>
+        <SystemPluginPage />
+      </CustomTabPanel>
+      <CustomTabPanel value={value} index={3}>
         <AboutViewServer dataServer={dataServer} />
       </CustomTabPanel>
     </Box>

--- a/src/components/SystemPluginPage.jsx
+++ b/src/components/SystemPluginPage.jsx
@@ -12,16 +12,16 @@ export default function SystemPluginPage() {
   return (
     <Stack spacing={2}>
       <Typography variant="body1">
-        Some functionalities rely on external utilities you need to install to
-        use.
+        {doI18n("pages:core-settings:system_plugins_intro", i18nRef.current)}
       </Typography>
 
       {/* FFmpeg for audio */}
       <Stack spacing={1}>
-        <Typography sx={{ fontWeight: "bold" }}>FFmpeg for audio</Typography>
+        <Typography sx={{ fontWeight: "bold" }}>
+          {doI18n("pages:core-settings:ffmpeg_title", i18nRef.current)}
+        </Typography>
         <Typography variant="body2">
-          FFmpeg is a multimedia framework. It is used for the audio editor, to
-          generate final audio files or to export Open Bible Stories videos.
+          {doI18n("pages:core-settings:ffmpeg_desc", i18nRef.current)}
         </Typography>
 
         <AssetDownloadButton asset="ffmpeg" />
@@ -30,10 +30,10 @@ export default function SystemPluginPage() {
       {/* Firefox for pdf */}
       <Stack spacing={1}>
         <Typography sx={{ fontWeight: "bold" }}>
-          Render engine for PDF
+          {doI18n("pages:core-settings:pdf_engine_title", i18nRef.current)}
         </Typography>
         <Typography variant="body2">
-          This render engine is used to generate large PDFs with complex fonts.
+          {doI18n("pages:core-settings:pdf_engine_desc", i18nRef.current)}
         </Typography>
 
         <AssetDownloadButton asset="firefox" />

--- a/src/components/SystemPluginPage.jsx
+++ b/src/components/SystemPluginPage.jsx
@@ -1,0 +1,43 @@
+import { useState, useEffect, useContext } from "react";
+import { Button, LinearProgress, Typography, Stack } from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import { i18nContext, netContext } from "pankosmia-rcl";
+import { doI18n } from "pankosmia-lib/i18n";
+import AssetDownloadButton from "./AssetDownloadButton";
+
+export default function SystemPluginPage() {
+  const { i18nRef } = useContext(i18nContext);
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="body1">
+        Some functionalities rely on external utilities you need to install to
+        use.
+      </Typography>
+
+      {/* FFmpeg for audio */}
+      <Stack spacing={1}>
+        <Typography sx={{ fontWeight: "bold" }}>FFmpeg for audio</Typography>
+        <Typography variant="body2">
+          FFmpeg is a multimedia framework. It is used for the audio editor, to
+          generate final audio files or to export Open Bible Stories videos.
+        </Typography>
+
+        <AssetDownloadButton asset="ffmpeg" />
+      </Stack>
+
+      {/* Firefox for pdf */}
+      <Stack spacing={1}>
+        <Typography sx={{ fontWeight: "bold" }}>
+          Render engine for PDF
+        </Typography>
+        <Typography variant="body2">
+          This render engine is used to generate large PDFs with complex fonts.
+        </Typography>
+
+        <AssetDownloadButton asset="firefox" />
+      </Stack>
+    </Stack>
+  );
+}


### PR DESCRIPTION
### Overview

This PR adds a new "System Plugins" tab in Settings that lets users download external assets (Firefox render engine and FFmpeg) from the app. https://github.com/pankosmia/core-client-settings/issues/58

> [!WARNING] 
> Warning: this PR depends on the API branch https://github.com/pankosmia/desktop-app-template/tree/run/AddFfmpeg

### Changes

- src/components/AssetDownloadButton.jsx (new): reusable download button component that calls Electron (window.electronAPI) to download/check an asset and shows progress. Could be moved to rcl later.
- src/components/SystemPluginPage.jsx (new): the new tab's page, listing the downloadable assets (FFmpeg + Firefox).
- src/components/Settings.jsx (edited): registers the new custom tab.
- pankosmia_metadata.json (edited): adds the i18n keys (en/fr) for the new tab and button.